### PR TITLE
Minor fixes.

### DIFF
--- a/src/Robo/Plugin/Commands/TestorCommands.php
+++ b/src/Robo/Plugin/Commands/TestorCommands.php
@@ -3,6 +3,7 @@
 namespace PL\Robo\Plugin\Commands;
 
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Consolidation\OutputFormatters\StructuredData\UnstructuredData;
 use Consolidation\OutputFormatters\StructuredData\UnstructuredListData;
 use PL\Robo\Common\TestorDependencyInjectorTrait;
 use PL\Robo\DO\Snapshot;
@@ -185,12 +186,12 @@ class TestorCommands extends \Robo\Tasks implements TestorConfigAwareInterface
     /**
      * Create a new preview on Tugboat.
      *
-     * @return UnstructuredListData Preview in Tugboat's format
+     * @return UnstructuredData Preview in Tugboat's format
      */
-    public function previewCreate(): UnstructuredListData
+    public function previewCreate(): UnstructuredData|Result
     {
         $result = $this->taskTugboatPreviewCreate()->run();
-        return $result['preview'] ? new UnstructuredListData($result['preview']) : $result;
+        return isset($result['preview']) ? new UnstructuredData($result['preview']) : $result;
     }
 
     /**

--- a/tests/Robo/Task/Testor/TugboatPreviewCreateTest.php
+++ b/tests/Robo/Task/Testor/TugboatPreviewCreateTest.php
@@ -13,6 +13,11 @@ class TugboatPreviewCreateTest extends TestorTestCase
             ->with('which tugboat')
             ->willReturn('/usr/bin/tugboat');
 
+        $mockFileExists = $this->mockBuiltIn('file_exists');
+        $mockFileExists->expects(self::once())
+            ->with(getenv('HOME') . '/.tugboat.yml')
+            ->willReturn(true);
+
         $mockDate = $this->mockBuiltIn('date');
         $mockDate->expects(self::once())
             ->willReturn('1970-01-01 00:00:00');

--- a/tests/Robo/Task/Testor/TugboatPreviewDeleteAllTest.php
+++ b/tests/Robo/Task/Testor/TugboatPreviewDeleteAllTest.php
@@ -13,6 +13,11 @@ class TugboatPreviewDeleteAllTest extends TestorTestCase
             ->with('which tugboat')
             ->willReturn('/usr/bin/tugboat');
 
+        $mockFileExists = $this->mockBuiltIn('file_exists');
+        $mockFileExists->expects(self::once())
+            ->with(getenv('HOME') . '/.tugboat.yml')
+            ->willReturn(true);
+
         /** @var TugboatPreviewDeleteAll $tugboatPreviewDeleteAll */
         $tugboatPreviewDeleteAll = $this->taskTugboatPreviewDeleteAll();
 

--- a/tests/Robo/Task/Testor/TugboatPreviewSetTest.php
+++ b/tests/Robo/Task/Testor/TugboatPreviewSetTest.php
@@ -22,6 +22,11 @@ class TugboatPreviewSetTest extends TestorTestCase
             ->with('which tugboat')
             ->willReturn('/usr/bin/tugboat');
 
+        $mockFileExists = $this->mockBuiltIn('file_exists');
+        $mockFileExists->expects(self::once())
+            ->with(getenv('HOME') . '/.tugboat.yml')
+            ->willReturn(true);
+
         $mockFileGetContents = $this->mockBuiltIn('file_get_contents');
         $mockFileGetContents->expects(self::exactly(2))
             ->withReturnMap([


### PR DESCRIPTION
 * preview:create command output as an object instead of list
 * fix error on handling the command's internal error
 * handle situation when tugboat exists but not configured, when archive exists.