### PR TITLE
Make Testor commands more atomic.

### DIFF
--- a/src/Robo/Task/Testor/SnapshotGet.php
+++ b/src/Robo/Task/Testor/SnapshotGet.php
@@ -18,7 +18,7 @@ class SnapshotGet extends TestorTask
   function __construct(array $args) {
     parent::__construct();
     $this->name = $args['name'];
-    $this->filename = $args['output'];
+    $this->filename = $args['output'] ?? null;
     $this->element = $args['element'];
   }
 
@@ -37,7 +37,7 @@ class SnapshotGet extends TestorTask
     $this->filename = $this->filename ?? end($array);
     $this->storage->get($name, $this->filename);
     $this->message = "Downloaded $name => $this->filename";
-    return $this->pass();
+    return $this->pass(['filename' => $this->filename]);
   }
 
 }

--- a/src/Robo/Task/Testor/SnapshotImport.php
+++ b/src/Robo/Task/Testor/SnapshotImport.php
@@ -3,7 +3,7 @@
 namespace PL\Robo\Task\Testor;
 
 class SnapshotImport extends TestorTask {
-  protected string $filename;
+  protected string|null $filename;
   /**
    * @var bool
    * Same as in {@link SnapshotCreate}
@@ -12,8 +12,19 @@ class SnapshotImport extends TestorTask {
 
   public function __construct(array $opts) {
     parent::__construct();
-    $this->filename = $opts['filename'];
+    $this->filename = $opts['filename'] ?? null;
     $this->gzip = $opts['gzip'] ?? true;
+  }
+
+  /**
+   * Configure filename.
+   *
+   * @param string $filename
+   * @return void
+   */
+  public function filename(string $filename): void {
+    // Cut off extension if any.
+    $this->filename = preg_replace('/(\.tar\.gz|\.sql)$/', '', $filename);
   }
 
   public function run(): \Robo\Result {

--- a/src/Robo/Task/Testor/SnapshotPut.php
+++ b/src/Robo/Task/Testor/SnapshotPut.php
@@ -16,7 +16,7 @@ class SnapshotPut extends TestorTask implements StorageAwareInterface {
   function __construct(array $opts) {
     parent::__construct();
     $this->name = $opts['name'];
-    if ($opts['localfilename']) {
+    if ($opts['localfilename'] ?? null) {
       $localfilename = $opts['localfilename'];
     }
     else {

--- a/src/Robo/Task/Testor/Tasks.php
+++ b/src/Robo/Task/Testor/Tasks.php
@@ -58,7 +58,7 @@ namespace PL\Robo\Task\Testor {
       return $this->task(TugboatPreviewCreate::class, $opts);
     }
 
-    protected function taskTugboatPreviewSet(string $preview): \Robo\Collection\CollectionBuilder {
+    protected function taskTugboatPreviewSet(string $preview = null): \Robo\Collection\CollectionBuilder {
       return $this->task(TugboatPreviewSet::class, $preview);
     }
 

--- a/src/Robo/Task/Testor/TestorTask.php
+++ b/src/Robo/Task/Testor/TestorTask.php
@@ -89,13 +89,14 @@ abstract class TestorTask extends \Robo\Task\BaseTask implements \Robo\Contract\
    * return $this->pass();
    * ```
    *
+   * @param array $data
    * @return Result
    */
-  public function pass(): Result {
+  public function pass(array $data = []): Result {
     // Print message, because by default Robo doesn't print successful
     // messages, and empty output may confuse user.
     $this->printTaskSuccess($this->message ?? 'passed');
-    return new Result($this, 0, $this->message);
+    return new Result($this, 0, $this->message, $data);
   }
 
   protected function checkRclone(): bool {

--- a/src/Robo/Task/Testor/TugboatPreviewDeleteAll.php
+++ b/src/Robo/Task/Testor/TugboatPreviewDeleteAll.php
@@ -15,7 +15,7 @@ class TugboatPreviewDeleteAll extends TugboatTask {
 
     $previews = json_decode($output, true);
     foreach ($previews as $preview) {
-      if ((bool) $preview['anchor']) {
+      if ((bool) ($preview['anchor'] ?? null)) {
         $this->printTaskInfo("Skip deleting anchor preview {$preview['preview']}");
         continue;
       }

--- a/src/Robo/Task/Testor/TugboatPreviewSet.php
+++ b/src/Robo/Task/Testor/TugboatPreviewSet.php
@@ -3,11 +3,26 @@
 namespace PL\Robo\Task\Testor;
 
 class TugboatPreviewSet extends TugboatTask {
-  protected string $preview;
+  protected string|null $preview;
 
-  public function __construct(string $preview) {
+  public function __construct(string|null $preview = null) {
     parent::__construct();
     $this->preview = $preview;
+  }
+
+  /**
+   * Configure preview to set.
+   *
+   * @param string|array $preview Preview ID or preview JSON.
+   * @return void
+   */
+  public function preview(string|array $preview): void {
+    if (is_array($preview)) {
+      $this->preview = $preview['preview'];
+    }
+    else {
+      $this->preview = $preview;
+    }
   }
 
   public function run(): \Robo\Result {

--- a/tests/Robo/Task/Testor/RegexTest.php
+++ b/tests/Robo/Task/Testor/RegexTest.php
@@ -11,7 +11,7 @@ class RegexTest extends TestCase {
 
     assertEquals('file', $m[1]);
     assertEquals('.sql', $m[2]);
-    assertEquals('', $m[3]);
+    assertEquals('', $m[3] ?? '');
   }
 
 }


### PR DESCRIPTION
E.g.
testor snapshot:create  #only create snapshot, not upload testor snapshot:create --put  #create and upload
testor snapshot:get  # download snapshot
testor snapshot:get --import  # download snapshot and apply to the current database testor preview:create  #create preview
testor preview:create --set  # create preview and set it to the ATK configs