### PR TITLE
feat(SnapshotGet): version pinning via optional --snapshot selector

### DIFF
--- a/src/Robo/Plugin/Commands/TestorCommands.php
+++ b/src/Robo/Plugin/Commands/TestorCommands.php
@@ -180,9 +180,13 @@ class TestorCommands extends \Robo\Tasks implements TestorConfigAwareInterface {
    * @option $output Output file. If not specified, original file name will be kept.
    * @option $element Element to get backups for (code, database, files)
    * @option $import Import database after download
+   * @option $snapshot Exact name of a specific snapshot to fetch (as shown in
+   * the "Name" column of `snapshot:list`). When omitted, the latest snapshot is
+   * fetched. When set, it must match exactly, or the command fails — it never
+   * silently falls back to the latest.
    * @return Result
    */
-  public function snapshotGet(array $opts = ['name' => '', 'output|o' => null, 'element' => 'database', 'import' => false]): Result {
+  public function snapshotGet(array $opts = ['name' => '', 'output|o' => null, 'element' => 'database', 'import' => false, 'snapshot' => null]): Result {
     $task = $this->collectionBuilder()->taskSnapshotGet($opts);
     if ($opts['import']) {
       $task

--- a/src/Robo/Task/Testor/SnapshotGet.php
+++ b/src/Robo/Task/Testor/SnapshotGet.php
@@ -14,12 +14,18 @@ class SnapshotGet extends TestorTask
   protected string $name;
   protected ?string $filename;
   protected string $element;
+  protected ?string $snapshot;
 
   function __construct(array $args) {
     parent::__construct();
     $this->name = $args['name'];
     $this->filename = $args['output'] ?? null;
     $this->element = $args['element'];
+    // Optional version pin. When null (default), the latest snapshot is
+    // used, preserving pre-existing behavior. When set, it must match a
+    // snapshot's `Name` exactly, or the task fails loudly (no silent
+    // fallback to latest).
+    $this->snapshot = $args['snapshot'] ?? null;
   }
 
   public function run() {
@@ -33,9 +39,29 @@ class SnapshotGet extends TestorTask
       return $this->fail();
     }
     // SnapshotList task returns `table` which
-    // contains a datetime-sorted array of objects.
-    // Key is the name of the first object.
-    $name = $result['table'][0]['Name'];
+    // contains a datetime-sorted array of objects (newest first).
+    if ($this->snapshot === null) {
+      // Default: take the latest (newest) snapshot — table[0].
+      $name = $result['table'][0]['Name'];
+    }
+    else {
+      // Pinned: select the snapshot whose `Name` matches exactly.
+      // An exact match is deliberate — a forgiving substring/prefix match
+      // could silently grab the wrong snapshot, which is strictly worse
+      // than a clear "not found" error.
+      $name = null;
+      foreach ($result['table'] as $row) {
+        if ($row['Name'] === $this->snapshot) {
+          $name = $row['Name'];
+          break;
+        }
+      }
+      if ($name === null) {
+        // Fail loudly — never silently fall back to latest.
+        $this->message = "No snapshot named \"$this->snapshot\" found for name \"$this->name\" (element \"$this->element\").";
+        return $this->fail();
+      }
+    }
     $array = explode('/', $name);
     $this->filename = $this->filename ?? end($array);
     $this->storage->get($name, $this->filename);

--- a/tests/Robo/Task/Testor/SnapshotGetTest.php
+++ b/tests/Robo/Task/Testor/SnapshotGetTest.php
@@ -161,6 +161,184 @@ class SnapshotGetTest extends TestorTestCase {
     self::assertEquals(0, $result->getExitCode());
   }
 
+  /**
+   * Default path (no --snapshot selector) must still return the latest
+   * (newest-dated) snapshot, exactly as before this feature existed.
+   *
+   * Fixture has THREE differently-dated database entries so that
+   * "picked table[0]" (latest, correct) is distinguishable from
+   * "picked some other entry". The newest is 2024-09-03 (the 3333 key),
+   * and that is the one that must be downloaded.
+   */
+  public function testSnapshotGetDefaultReturnsLatest() {
+    /** @var SnapshotGet $snapshotGet */
+    $snapshotGet = $this->taskSnapshotGet(['name' => 'test', 'output' => 'test.sql.gz', 'element' => 'database']);
+
+    $this->mockS3Client->shouldReceive('listObjects')
+      ->once()
+      ->with(array(
+        'Bucket' => 'snapshot',
+        'Delimiter' => ':',
+        'Prefix' => 'test'
+      ))
+      ->andReturn(array(
+        'Contents' => array(
+          // Deliberately NOT in date order in the raw listing —
+          // StorageS3::list() sorts newest-first.
+          array(
+            'Key' => 'test/performant-labs_1111_database.sql.gz',
+            'LastModified' => new \DateTime('2024-09-01'),
+            'Size' => '1234'
+          ),
+          array(
+            'Key' => 'test/performant-labs_3333_database.sql.gz',
+            'LastModified' => new \DateTime('2024-09-03'),
+            'Size' => '3333'
+          ),
+          array(
+            'Key' => 'test/performant-labs_2222_database.sql.gz',
+            'LastModified' => new \DateTime('2024-09-02'),
+            'Size' => '2222'
+          )
+        )
+      ));
+    // Latest by date is the 3333 key; that is what must be downloaded.
+    $this->mockS3Client->shouldReceive('getObject')
+      ->once()
+      ->with(array(
+        'Bucket' => 'snapshot',
+        'Key' => 'test/performant-labs_3333_database.sql.gz',
+        'SaveAs' => 'test.sql.gz'
+      ))
+      ->andReturn(array());
+
+    $snapshotList = $this->taskSnapshotList(['name' => 'test', 'element' => 'database']);
+    $mockBuilder = $this->mockCollectionBuilder();
+    $mockBuilder->shouldReceive('taskSnapshotList')
+      ->once()
+      ->with(['name' => 'test', 'element' => 'database'])
+      ->andReturn($snapshotList);
+    $snapshotGet->setBuilder($mockBuilder);
+
+    $result = $snapshotGet->run();
+    self::assertEquals(0, $result->getExitCode());
+  }
+
+  /**
+   * Pinned path: an explicit --snapshot selector must fetch THAT specific
+   * object, not the latest. Here the latest is the 3333 key (2024-09-03)
+   * but we pin the 1111 key (2024-09-01) — so a "picked table[0] by accident"
+   * bug would download 3333 and fail this test.
+   */
+  public function testSnapshotGetPinnedReturnsSelected() {
+    /** @var SnapshotGet $snapshotGet */
+    $snapshotGet = $this->taskSnapshotGet([
+      'name' => 'test',
+      'output' => 'test.sql.gz',
+      'element' => 'database',
+      'snapshot' => 'test/performant-labs_1111_database.sql.gz',
+    ]);
+
+    $this->mockS3Client->shouldReceive('listObjects')
+      ->once()
+      ->with(array(
+        'Bucket' => 'snapshot',
+        'Delimiter' => ':',
+        'Prefix' => 'test'
+      ))
+      ->andReturn(array(
+        'Contents' => array(
+          array(
+            'Key' => 'test/performant-labs_1111_database.sql.gz',
+            'LastModified' => new \DateTime('2024-09-01'),
+            'Size' => '1234'
+          ),
+          array(
+            'Key' => 'test/performant-labs_3333_database.sql.gz',
+            'LastModified' => new \DateTime('2024-09-03'),
+            'Size' => '3333'
+          ),
+          array(
+            'Key' => 'test/performant-labs_2222_database.sql.gz',
+            'LastModified' => new \DateTime('2024-09-02'),
+            'Size' => '2222'
+          )
+        )
+      ));
+    // The pinned 1111 key must be downloaded, NOT the newest 3333.
+    $this->mockS3Client->shouldReceive('getObject')
+      ->once()
+      ->with(array(
+        'Bucket' => 'snapshot',
+        'Key' => 'test/performant-labs_1111_database.sql.gz',
+        'SaveAs' => 'test.sql.gz'
+      ))
+      ->andReturn(array());
+
+    $snapshotList = $this->taskSnapshotList(['name' => 'test', 'element' => 'database']);
+    $mockBuilder = $this->mockCollectionBuilder();
+    $mockBuilder->shouldReceive('taskSnapshotList')
+      ->once()
+      ->with(['name' => 'test', 'element' => 'database'])
+      ->andReturn($snapshotList);
+    $snapshotGet->setBuilder($mockBuilder);
+
+    $result = $snapshotGet->run();
+    self::assertEquals(0, $result->getExitCode());
+  }
+
+  /**
+   * Not-found path: a --snapshot selector that matches nothing in the bucket
+   * must fail loudly (non-zero exit) and NEVER silently fall back to latest.
+   * The critical guarantee is that getObject is never called — if it were,
+   * the operator would think they restored the pinned version but actually
+   * got latest. Mockery verifies getObject is not invoked (no expectation set).
+   */
+  public function testSnapshotGetPinnedNotFoundFailsLoudly() {
+    /** @var SnapshotGet $snapshotGet */
+    $snapshotGet = $this->taskSnapshotGet([
+      'name' => 'test',
+      'output' => 'test.sql.gz',
+      'element' => 'database',
+      'snapshot' => 'test/performant-labs_9999_database.sql.gz',
+    ]);
+
+    $this->mockS3Client->shouldReceive('listObjects')
+      ->once()
+      ->with(array(
+        'Bucket' => 'snapshot',
+        'Delimiter' => ':',
+        'Prefix' => 'test'
+      ))
+      ->andReturn(array(
+        'Contents' => array(
+          array(
+            'Key' => 'test/performant-labs_1111_database.sql.gz',
+            'LastModified' => new \DateTime('2024-09-01'),
+            'Size' => '1234'
+          ),
+          array(
+            'Key' => 'test/performant-labs_2222_database.sql.gz',
+            'LastModified' => new \DateTime('2024-09-02'),
+            'Size' => '2222'
+          )
+        )
+      ));
+    // NO getObject expectation: if run() falls back to latest and downloads,
+    // Mockery will fail the test on the unexpected call.
+
+    $snapshotList = $this->taskSnapshotList(['name' => 'test', 'element' => 'database']);
+    $mockBuilder = $this->mockCollectionBuilder();
+    $mockBuilder->shouldReceive('taskSnapshotList')
+      ->once()
+      ->with(['name' => 'test', 'element' => 'database'])
+      ->andReturn($snapshotList);
+    $snapshotGet->setBuilder($mockBuilder);
+
+    $result = $snapshotGet->run();
+    self::assertEquals(1, $result->getExitCode());
+  }
+
   public function testSnapshotGetNoResult() {
     /** @var SnapshotGet $snapshotGet */
     $snapshotGet = $this->taskSnapshotGet(['name' => 'test', 'output' => 'test.sql.gz', 'element' => 'database']);


### PR DESCRIPTION
## What

Adds an optional `--snapshot=<name>` selector to the `SnapshotGet` task and its `snapshot:get` CLI command, so an operator can fetch a **specific, non-latest** snapshot instead of only the newest one.

- **Omitted (default):** unchanged behavior — fetches the latest (newest-dated) snapshot, `table[0]` from `SnapshotList`'s datetime-sorted result. Zero behavior change for existing callers.
- **Set:** fetches the snapshot whose `Name` matches **exactly** (the `Name` column as shown by `snapshot:list`).

## Design decisions

**Exact match, not substring/prefix.** A forgiving match risks silently grabbing the wrong snapshot, which is strictly worse than a clear "not found" error. The selector is compared with `===` against each row's `Name`.

**No silent fallback to latest.** A selector matching nothing in the bucket fails loudly — non-zero exit with a clear message naming the missing snapshot — and never downloads latest instead. A silent fallback here would let an operator believe they restored version X when they actually got latest; that is the one failure a test explicitly proves cannot happen (the not-found test asserts `getObject` is never called).

## Tests (added to `SnapshotGetTest`)

- **Default returns latest** — proven against a **3-entry** fixture whose newest entry (`2024-09-03`) is deliberately *not* first in the raw S3 listing, so "picked latest" is distinguishable from "picked table[0] by position". **Mutation-verified:** changing the default selection to `table[1]` turns this test red; restoring turns it green.
- **Pinned returns selected** — pins the `2024-09-01` entry while latest is `2024-09-03`, so an accidental "always table[0]" would download the wrong object and fail.
- **Not-found fails loudly** — a non-existent selector yields exit 1 and, critically, no `getObject` call (Mockery fails on any unexpected call).

Full suite: 36 tests / 158 assertions green (was 33/147). `phpstan analyze tests/ src/` clean. Scope limited to `SnapshotGet.php`, its CLI command in `TestorCommands.php`, and `SnapshotGetTest.php`.

Addresses #26. Part of epic #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)