### PR TITLE
fix(snapshot): normalize Drupal site UUID on restore (DbUuidNormalize)

### DIFF
--- a/src/Robo/Task/Testor/DbUuidNormalize.php
+++ b/src/Robo/Task/Testor/DbUuidNormalize.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace PL\Robo\Task\Testor;
+
+use PL\Robo\Common\TestorConfigAwareTrait;
+use PL\Robo\Contract\TestorConfigAwareInterface;
+
+/**
+ * Normalize the Drupal site UUID in a restored database.
+ *
+ * Drupal's config-sync system refuses to import configuration whose
+ * `system.site:uuid` differs from the target (active) storage —
+ * `\Drupal\Core\Config\StorageComparer::validateSiteUuid()` requires
+ * `$source['uuid'] === $target['uuid']`, and `drush config:import` aborts with
+ * "Site UUID in source storage does not match the target storage." (fatal).
+ *
+ * A Pantheon-prod snapshot carries prod's uuid; a fresh Flotilla preview (or
+ * any differently-installed environment) has a different active uuid. This task
+ * is the consumer-side massaging step that reconciles them: it overwrites the
+ * active `system.site:uuid` with a caller-supplied target uuid so the target
+ * config (typically the repo's committed `config/sync`) can be imported.
+ *
+ * The massaging lives on the CONSUMER (restore) side, not the producer side,
+ * because the correct uuid is a property of the target environment, not of the
+ * snapshot: the same snapshot legitimately restores into many targets, each of
+ * which may want a different resulting uuid. See the issue #25 write-up.
+ *
+ * Mirrors {@see DbSanitize}: a config-driven database transformation that is a
+ * no-op unless configured — it never invents a uuid.
+ */
+class DbUuidNormalize extends TestorTask implements TestorConfigAwareInterface {
+  use TestorConfigAwareTrait;
+
+  /**
+   * Placeholder in a configured `uuid.command` that is replaced with the
+   * resolved target uuid before execution.
+   */
+  protected const PLACEHOLDER = '%uuid%';
+
+  /**
+   * Default massaging command when the project configures no `uuid.command`.
+   * Safe and surgical: `drush config:set` updates only the `system.site` uuid
+   * key rather than blindly rewriting the serialized `config` blob.
+   */
+  protected const DEFAULT_COMMAND = 'drush config:set system.site uuid ' . self::PLACEHOLDER . ' -y';
+
+  /**
+   * RFC-4122-shaped uuid. Deliberately strict: the resolved value is
+   * interpolated into a shell command, so anything that is not a bare uuid must
+   * be rejected before it can reach the shell (both operator-error and
+   * injection defence).
+   */
+  protected const UUID_PATTERN = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/';
+
+  protected string|null $uuid;
+
+  public function __construct(array $opts) {
+    parent::__construct();
+    $this->uuid = $opts['uuid'] ?? null;
+  }
+
+  public function run(): \Robo\Result {
+    // Resolve the target uuid: explicit --uuid option wins over config default.
+    $uuid = $this->uuid ?? $this->testorConfig->get('uuid.value');
+
+    if ($uuid === null || $uuid === '') {
+      $this->message = 'Skip UUID normalization, because no target uuid is set '
+        . '(pass --uuid or set uuid.value in .testor.yml)';
+      return $this->pass();
+    }
+
+    if (!is_string($uuid) || !preg_match(self::UUID_PATTERN, $uuid)) {
+      $this->message = "Refusing to normalize: '$uuid' is not a valid uuid";
+      return $this->fail();
+    }
+
+    $command = $this->testorConfig->get('uuid.command') ?? self::DEFAULT_COMMAND;
+    $command = str_replace(self::PLACEHOLDER, $uuid, $command);
+
+    return $this->exec($command);
+  }
+
+}

--- a/src/Robo/Task/Testor/Tasks.php
+++ b/src/Robo/Task/Testor/Tasks.php
@@ -26,6 +26,10 @@ namespace PL\Robo\Task\Testor {
       return $this->task(DbSanitize::class, $opts);
     }
 
+    protected function taskDbUuidNormalize(array $opts): \Robo\Collection\CollectionBuilder {
+      return $this->task(DbUuidNormalize::class, $opts);
+    }
+
     protected function taskSnapshotCreate(array $opts): \Robo\Collection\CollectionBuilder {
       return $this->task(SnapshotCreate::class, $opts);
     }

--- a/tests/Robo/Task/Testor/DbUuidNormalizeTest.php
+++ b/tests/Robo/Task/Testor/DbUuidNormalizeTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace PL\Tests\Robo\Task\Testor {
+
+  use PL\Robo\Task\Testor\DbUuidNormalize;
+
+  /**
+   * Tests for {@see DbUuidNormalize}, the consumer-side Drupal site-UUID
+   * massaging step (issue #25).
+   *
+   * The task normalizes the active `system.site:uuid` in a restored database
+   * so that a Pantheon-prod snapshot imports cleanly into a differently-UUID'd
+   * Drupal environment (a fresh Flotilla preview). See docs/handoffs for the
+   * reproduced failure ("Site UUID in source storage does not match the target
+   * storage.").
+   */
+  class DbUuidNormalizeTest extends TestorTestCase {
+
+    /**
+     * With no target uuid resolvable at all, the task skips (like DbSanitize
+     * skips when sanitize.command is unset) — it must never invent a uuid.
+     */
+    public function testSkipsWhenNoUuidConfigured() {
+      $mockBuilder = $this->mockCollectionBuilder();
+      $dbUuidNormalize = $this->taskDbUuidNormalize([]);
+      $mockBuilder->shouldReceive('taskExec')->never();
+      $dbUuidNormalize->setBuilder($mockBuilder);
+
+      $result = $dbUuidNormalize->run();
+      self::assertEquals(0, $result->getExitCode());
+      self::assertStringContainsString('Skip', $result->getMessage());
+    }
+
+    /**
+     * The `--uuid` option supplies the target uuid; with no custom command
+     * configured the task runs the safe default `drush config:set`, with the
+     * uuid substituted in. This is the decisive assertion: the EXACT uuid the
+     * caller asked for must reach the executed command.
+     */
+    public function testRunsDefaultCommandWithOptionUuid() {
+      $uuid = 'a0030de7-5e41-4016-908d-3e0845e30acb';
+      $mockBuilder = $this->mockCollectionBuilder();
+      $dbUuidNormalize = $this->taskDbUuidNormalize(['uuid' => $uuid]);
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with("drush config:set system.site uuid $uuid -y")
+        ->andReturn($this->mockTaskExec($dbUuidNormalize, 0, 'OK'));
+      $dbUuidNormalize->setBuilder($mockBuilder);
+
+      $result = $dbUuidNormalize->run();
+      self::assertEquals(0, $result->getExitCode());
+    }
+
+    /**
+     * A site may configure its own massaging command via `uuid.command`,
+     * using the `%uuid%` placeholder. The task substitutes the resolved target
+     * uuid into every occurrence of the placeholder. This is what keeps the
+     * task generic (config-driven, not performantlabs.com-hardcoded) and lets a
+     * site use raw SQL when drush isn't bootstrappable.
+     */
+    public function testSubstitutesUuidIntoConfiguredCommand() {
+      $uuid = '5d00dfdf-9614-48ed-91ba-d902cbb96b05';
+      /** @var \Consolidation\Config\Config $testorConfig */
+      $testorConfig = $this->getContainer()->get('testorConfig');
+      $testorConfig->set(
+        'uuid.command',
+        'drush sql:query "UPDATE config SET data = REPLACE(data, uuid_placeholder, %uuid%) WHERE name = \'system.site\'"'
+      );
+      $mockBuilder = $this->mockCollectionBuilder();
+      $dbUuidNormalize = $this->taskDbUuidNormalize(['uuid' => $uuid]);
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with("drush sql:query \"UPDATE config SET data = REPLACE(data, uuid_placeholder, $uuid) WHERE name = 'system.site'\"")
+        ->andReturn($this->mockTaskExec($dbUuidNormalize, 0, 'OK'));
+      $dbUuidNormalize->setBuilder($mockBuilder);
+
+      $result = $dbUuidNormalize->run();
+      self::assertEquals(0, $result->getExitCode());
+    }
+
+    /**
+     * The target uuid may also come from config (`uuid.value`) rather than the
+     * option, e.g. a project pins the uuid its committed config/sync expects.
+     * The explicit option still wins over config (tested below); here config is
+     * the only source.
+     */
+    public function testResolvesUuidFromConfigValue() {
+      $uuid = 'deadbeef-0000-4000-8000-000000000000';
+      /** @var \Consolidation\Config\Config $testorConfig */
+      $testorConfig = $this->getContainer()->get('testorConfig');
+      $testorConfig->set('uuid.value', $uuid);
+      $mockBuilder = $this->mockCollectionBuilder();
+      $dbUuidNormalize = $this->taskDbUuidNormalize([]);
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with("drush config:set system.site uuid $uuid -y")
+        ->andReturn($this->mockTaskExec($dbUuidNormalize, 0, 'OK'));
+      $dbUuidNormalize->setBuilder($mockBuilder);
+
+      $result = $dbUuidNormalize->run();
+      self::assertEquals(0, $result->getExitCode());
+    }
+
+    /**
+     * The explicit `--uuid` option overrides a configured `uuid.value`.
+     */
+    public function testOptionUuidOverridesConfigValue() {
+      $configUuid = 'deadbeef-0000-4000-8000-000000000000';
+      $optionUuid = 'a0030de7-5e41-4016-908d-3e0845e30acb';
+      /** @var \Consolidation\Config\Config $testorConfig */
+      $testorConfig = $this->getContainer()->get('testorConfig');
+      $testorConfig->set('uuid.value', $configUuid);
+      $mockBuilder = $this->mockCollectionBuilder();
+      $dbUuidNormalize = $this->taskDbUuidNormalize(['uuid' => $optionUuid]);
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with("drush config:set system.site uuid $optionUuid -y")
+        ->andReturn($this->mockTaskExec($dbUuidNormalize, 0, 'OK'));
+      $dbUuidNormalize->setBuilder($mockBuilder);
+
+      $result = $dbUuidNormalize->run();
+      self::assertEquals(0, $result->getExitCode());
+    }
+
+    /**
+     * A malformed uuid must be rejected before it ever reaches the shell —
+     * this both catches operator error and blocks command injection through
+     * the substituted value.
+     */
+    public function testRejectsMalformedUuid() {
+      $mockBuilder = $this->mockCollectionBuilder();
+      $dbUuidNormalize = $this->taskDbUuidNormalize(['uuid' => 'not-a-uuid; rm -rf /']);
+      $mockBuilder->shouldReceive('taskExec')->never();
+      $dbUuidNormalize->setBuilder($mockBuilder);
+
+      $result = $dbUuidNormalize->run();
+      self::assertEquals(1, $result->getExitCode());
+      self::assertStringContainsString('uuid', strtolower($result->getMessage()));
+    }
+
+    /**
+     * A failing massaging command propagates its non-zero exit code and error
+     * text (mirrors DbSanitize / SnapshotCreate error propagation).
+     */
+    public function testPropagatesCommandFailure() {
+      $uuid = 'a0030de7-5e41-4016-908d-3e0845e30acb';
+      $mockBuilder = $this->mockCollectionBuilder();
+      $dbUuidNormalize = $this->taskDbUuidNormalize(['uuid' => $uuid]);
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with("drush config:set system.site uuid $uuid -y")
+        ->andReturn($this->mockTaskExec(new \Robo\Result($dbUuidNormalize, 1, 'SPOOKY SCARY ERROR')));
+      $dbUuidNormalize->setBuilder($mockBuilder);
+
+      $result = $dbUuidNormalize->run();
+      self::assertEquals(1, $result->getExitCode());
+      self::assertStringContainsString('SPOOKY SCARY ERROR', $result->getMessage());
+    }
+
+  }
+}


### PR DESCRIPTION
## Summary

Diagnoses and fixes what breaks when a Pantheon-prod DB snapshot is imported into a
differently-UUID'd Drupal environment (the motivating case: a fresh Flotilla preview for
performantlabs.com), and implements the massaging step.

Addresses #25. Part of epic #24.

## The actual failure mode (reproduced live, not assumed)

Drupal's config-sync system refuses to import configuration whose site UUID doesn't match
the target. The enforcement is `\Drupal\Core\Config\StorageComparer::validateSiteUuid()`
(Drupal core 11.x), which reads `system.site` from source and target storage and requires:

```php
return $source && $target && $source['uuid'] === $target['uuid'];
```

When they differ, `drush config:import` aborts (fatal, exit 1) with:

```
The import failed due to the following reasons:
Site UUID in source storage does not match the target storage.
```

**Reproduced end-to-end** in a real DDEV **Drupal 11.4.5 / PHP 8.3 / MariaDB** site
(matching performantlabs.com's stack):

1. Installed "site A" (prod), uuid `a0030de7-…`; exported its config; took a full
   `drush sql:dump` (exactly what Testor's `SnapshotCreate` produces).
2. Re-installed as a fresh "site B" (preview), uuid `5d00dfdf-…`.
3. `drush config:import` against config carrying a different uuid →
   **"Site UUID in source storage does not match the target storage."** (both directions:
   committed-config=prod vs DB=fresh, and committed-config=dev vs DB=prod).
4. Applied the fix (`drush config:set system.site uuid <target> -y`) → `config:import`
   then succeeds ("There are no changes to import").

### Ruled out
It is **not** an entity/content UUID collision. Testor imports a *whole* SQL dump
(`SnapshotImport`: `sql.command < file.sql`), which replaces all tables wholesale — no
row-level collision is possible. After a full-dump restore, the active `system.site:uuid`
*is* the dump's uuid; the mismatch only surfaces at the later `config:import` step against
config carrying a different uuid.

## Design decision: consumer-side (restore-time), per-target — matters for #27/#28

The massaging belongs on the **consumer** (restore) side, not the producer side, because
the correct uuid is a property of the **target environment**, not of the snapshot. The same
snapshot legitimately restores into many targets (a prod-clone that wants prod's uuid; each
preview that must match the uuid in the repo's committed `config/sync`; a developer's local).
Baking one uuid into the snapshot at produce-time would be wrong for every target but one and
would force a re-produce to retarget.

Consequences for the sibling stories in epic #24:
- **#27 (producer)** does **not** apply uuid massaging — it keeps producing a faithful,
  sanitized dump carrying prod's uuid.
- **#28 (consumer)** invokes this task after restore, around `config:import`, with a target
  uuid resolved per-restore (default: the uuid in the repo's committed
  `config/sync/system.site.yml`; overridable).

## Implementation

New Robo task `DbUuidNormalize` (mirrors `DbSanitize` — a config-driven DB transformation
that is a **no-op unless configured**, never invents a uuid):

- Resolves the target uuid from `--uuid` (option) → `uuid.value` (config) → else skip.
- Runs `uuid.command` if configured (with a `%uuid%` placeholder substituted), else a safe
  default: `drush config:set system.site uuid %uuid% -y`. `config:set` is deliberately
  surgical — it updates only the `system.site` uuid key, rather than blindly rewriting the
  PHP-serialized `config` blob (a blind `sed` on the dump could match other 36-char strings).
- Rejects malformed uuids before they can reach the shell (operator-error + injection defence).
- Registered in `Task/Testor/Tasks.php` as `taskDbUuidNormalize()` so #28's consumer command
  can chain it. Not performantlabs.com-specific: the uuid and command are config/option-driven.

## Verification

- New unit suite `DbUuidNormalizeTest` (7 tests, 22 assertions) exercises the real
  transformation logic — option/config resolution, `%uuid%` substitution into both the
  default and a custom raw-SQL command, precedence, malformed-uuid rejection, and failure
  propagation.
- **Mutation test of the decisive assertion:** removing the `str_replace` substitution makes
  `testRunsDefaultCommandWithOptionUuid` and `testSubstitutesUuidIntoConfiguredCommand` go
  red for the right reason (executed command retains the literal `%uuid%` placeholder instead
  of the real uuid); restoring makes them green.
- **Live end-to-end:** the exact default command the task emits flips a failing
  `config:import` into a passing one on the DDEV Drupal 11.4.5 site.
- Full suite green: **40 tests, 169 assertions** (33 baseline + 7). `phpstan analyze -vvv
  tests/ src/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
