### PR TITLE
feat(snapshot): snapshot:refresh generic producer command

### DIFF
--- a/.testor_generic_test.yml
+++ b/.testor_generic_test.yml
@@ -1,0 +1,15 @@
+# A deliberately non-performantlabs.com fixture, used to prove that
+# snapshot:refresh (the producer orchestration) is fully config-driven and
+# hardcodes nothing about any particular project. Every value below is
+# fictional and distinct from .testor_test.yml's shape.
+pantheon:
+  site: 'acme-widgets'
+s3:
+  config: '**DUMMY**'
+  bucket: 'nightly-dumps'
+sql:
+  command: '$(drush sql:connect)'
+sqldump:
+  command: 'drush sql:dump'
+sanitize:
+  command: 'drush sql:sanitize --sanitize-email=redacted@example.test'

--- a/src/Robo/Plugin/Commands/TestorCommands.php
+++ b/src/Robo/Plugin/Commands/TestorCommands.php
@@ -123,6 +123,63 @@ class TestorCommands extends \Robo\Tasks implements TestorConfigAwareInterface {
   }
 
   /**
+   * Refresh a snapshot: (optionally) pull from the source environment,
+   * sanitize, then push to the configured storage — in one repeatable,
+   * config-driven command.
+   *
+   * This is the generic producer orchestration (epic #24). It chains the
+   * existing primitives (SnapshotViaBackup/SnapshotCreate, DbSanitize,
+   * SnapshotPut). Everything (Pantheon site, sanitization rules, bucket) comes
+   * from .testor.yml; nothing is hardcoded to any project.
+   *
+   * There is deliberately NO UUID-normalization step here: per issue #25 the
+   * Drupal site-UUID massaging is a consumer-side (restore-time) concern, since
+   * the correct uuid is a property of the target environment, not the snapshot.
+   * That belongs to the consumer command (issue #28).
+   *
+   * The chain short-circuits: if sanitize fails, the unsanitized dump is never
+   * pushed to storage.
+   *
+   * @param string $file Local dump to operate on when --skip-download is set
+   * (reuses an already-local dump instead of pulling a fresh one). Ignored when
+   * pulling. If empty in --skip-download mode, a filename is derived the same
+   * way as a fresh local pull would.
+   * @param array $opts
+   * @option $env It can be either '@self' (current database), a Drush alias,
+   * or a Pantheon env
+   * @option $name Name of the snapshot, such as "developer" or "preview",
+   * will be prefixed to the real unique snapshot name (it can be thought
+   * as a folder)
+   * @option $element Element to refresh (currently database)
+   * @option $do-not-sanitize Skip database sanitize command
+   * @option $skip-download Skip the pull stage and re-sanitize/re-push an
+   * already-local dump (do not hit the source environment again)
+   * @return Result
+   */
+  public function snapshotRefresh(string $file = '', array $opts = ['env' => '@self', 'name' => 'default', 'element' => 'database', 'do-not-sanitize' => false, 'skip-download' => false]): Result {
+    $env = $opts['env'];
+    $ispantheon = !str_starts_with($env, '@');
+
+    // Normalize element.
+    $element = $this->normalizeElement($opts);
+
+    if ($opts['skip-download'] && $file !== '') {
+      // Reuse the caller-supplied local dump. Derive the extension-less base
+      // name the same way snapshot:put does, so SnapshotPut finds the archive.
+      preg_match('/(.*?)(\.tar|\.sql)?(\.gz)?$/', $file, $m);
+      $filename = $m[1];
+    }
+    else {
+      // Make a target file name (without extension; it becomes .tar.gz later).
+      $filename = $this->getSnapshotFilename($ispantheon ? $env : 'local', $element);
+    }
+    $opts['filename'] = $filename;
+
+    $result = $this->collectionBuilder()->taskSnapshotRefresh($opts)->run();
+    return $this->echo($result);
+  }
+
+  /**
    * Put snapshot from the local file system to the storage.
    *
    * @param string $file Local file name

--- a/src/Robo/Task/Testor/SnapshotRefresh.php
+++ b/src/Robo/Task/Testor/SnapshotRefresh.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace PL\Robo\Task\Testor;
+
+use PL\Robo\Common\TestorConfigAwareTrait;
+use PL\Robo\Contract\TestorConfigAwareInterface;
+use Robo\Common\BuilderAwareTrait;
+use Robo\Result;
+
+/**
+ * Generic producer orchestration: (optionally) pull a fresh snapshot from the
+ * source environment, sanitize it, then push it to the configured storage.
+ *
+ * This is the producer half of the epic-#24 pipeline. It chains the existing
+ * primitives — {@see SnapshotViaBackup}/{@see SnapshotCreate}, {@see DbSanitize},
+ * {@see SnapshotPut} — into one repeatable, config-driven command. Everything
+ * (Pantheon site, sanitization rules, bucket) comes from `.testor.yml`; nothing
+ * is hardcoded to any particular project.
+ *
+ * Deliberately NO UUID-normalization step. Per issue #25's settled design, the
+ * Drupal site-UUID massaging ({@see DbUuidNormalize}) is a CONSUMER-side
+ * (restore-time), per-target concern: the correct uuid is a property of the
+ * target environment, not of the snapshot, since the same snapshot legitimately
+ * restores into many differently-UUID'd targets. Adding it here would build a
+ * parallel path that contradicts that design. It belongs to the consumer
+ * command (issue #28) instead.
+ *
+ * The chain short-circuits: each stage's result is checked, and a failure
+ * returns immediately so that no later stage runs (e.g. a failed sanitize must
+ * never push an unsanitized dump to storage).
+ *
+ * Mirrors {@see SnapshotGet}'s orchestration style: it drives sub-tasks through
+ * `collectionBuilder()->taskX()->run()` and inspects each Result, rather than
+ * shelling out to the `testor` binary from within itself.
+ */
+class SnapshotRefresh extends TestorTask implements TestorConfigAwareInterface {
+  use BuilderAwareTrait;
+  use TestorConfigAwareTrait;
+
+  /**
+   * When true, the pull stage is skipped and the chain operates on an
+   * already-local dump (re-sanitize / re-push without hitting the source
+   * environment again).
+   */
+  protected bool $skipDownload;
+
+  /**
+   * Full option bag, forwarded to each sub-task (env, name, element,
+   * do-not-sanitize, filename, …). Sub-tasks read only the keys they need.
+   *
+   * @var array
+   */
+  protected array $opts;
+
+  public function __construct(array $opts) {
+    parent::__construct();
+    $this->skipDownload = (bool) ($opts['skip-download'] ?? false);
+    $this->opts = $opts;
+  }
+
+  public function run(): Result {
+    $opts = $this->opts;
+
+    // Stage 1 (optional): pull a fresh snapshot from the source environment.
+    if (!$this->skipDownload) {
+      $result = $this->pull($opts);
+      if (!$result->wasSuccessful()) {
+        return $result;
+      }
+    }
+
+    // Stage 2: sanitize the (local) dump.
+    $result = $this->collectionBuilder()->taskDbSanitize($opts)->run();
+    if (!$result->wasSuccessful()) {
+      // Short-circuit: never push an unsanitized dump.
+      return $result;
+    }
+
+    // Stage 3: push the sanitized result to the configured storage.
+    return $this->collectionBuilder()->taskSnapshotPut($opts)->run();
+  }
+
+  /**
+   * Pull a fresh snapshot from the source environment.
+   *
+   * A Pantheon env (name not starting with '@') uses the backup-based path
+   * ({@see SnapshotViaBackup}); a local/Drush-alias env uses a local dump
+   * ({@see SnapshotCreate}). This mirrors the branch already in
+   * {@see \PL\Robo\Plugin\Commands\TestorCommands::snapshotCreate()}.
+   */
+  protected function pull(array $opts): Result {
+    $env = $opts['env'];
+    $ispantheon = !str_starts_with($env, '@');
+
+    if ($ispantheon) {
+      return $this->collectionBuilder()->taskSnapshotViaBackup($opts)->run();
+    }
+
+    return $this->collectionBuilder()
+      ->taskSnapshotCreate([...$opts, 'ispantheon' => false])
+      ->run();
+  }
+
+}

--- a/src/Robo/Task/Testor/Tasks.php
+++ b/src/Robo/Task/Testor/Tasks.php
@@ -46,6 +46,10 @@ namespace PL\Robo\Task\Testor {
       return $this->task(SnapshotViaBackup::class, $opts);
     }
 
+    protected function taskSnapshotRefresh(array $opts): \Robo\Collection\CollectionBuilder {
+      return $this->task(SnapshotRefresh::class, $opts);
+    }
+
     protected function taskSnapshotList(array $opts): \Robo\Collection\CollectionBuilder {
       return $this->task(SnapshotList::class, $opts);
     }

--- a/tests/Robo/Task/Testor/SnapshotRefreshGenericConfigTest.php
+++ b/tests/Robo/Task/Testor/SnapshotRefreshGenericConfigTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace PL\Tests\Robo\Task\Testor {
+
+  use Aws\S3\S3Client;
+  use PL\Robo\Common\StorageStrategy;
+  use PL\Robo\Testor;
+  use Robo\Robo;
+  use Symfony\Component\Console\Output\NullOutput;
+
+  /**
+   * Proves {@see \PL\Robo\Task\Testor\SnapshotRefresh} is generic — fully
+   * config-driven, with NOTHING hardcoded about performantlabs.com.
+   *
+   * It rebuilds the Robo container against a second, deliberately fictional
+   * config fixture (`.testor_generic_test.yml`: site `acme-widgets`, bucket
+   * `nightly-dumps`, a custom sanitize command) and runs the same producer
+   * chain. The assertions are that the FIXTURE'S OWN values — not any
+   * performantlabs.com value — reach the executed commands and the S3 client:
+   *   - the Pantheon site `acme-widgets` in the terminus commands,
+   *   - the custom sanitize command,
+   *   - the bucket `nightly-dumps` in the putObject call.
+   *
+   * If the command hardcoded performant-labs / snapshot anywhere, these
+   * assertions would fail.
+   */
+  class SnapshotRefreshGenericConfigTest extends TestorTestCase {
+
+    public function setUp(): void {
+      // Rebuild the container against the generic (non-performantlabs.com)
+      // fixture instead of the default .testor_test.yml.
+      $container = Robo::createDefaultContainer(null, new NullOutput());
+      $container->add('testorConfig', Testor::createConfiguration(['.testor_generic_test.yml']));
+      $container->add('s3Client', $this->mockS3Client());
+      // Bucket comes from the generic fixture, mirroring production wiring.
+      $container->add('s3Bucket', 'nightly-dumps');
+      $container->add('storage', StorageStrategy::class);
+      $this->setContainer($container);
+    }
+
+    public function tearDown(): void {
+      parent::tearDown();
+      foreach (['__generic_refresh.tar.gz'] as $f) {
+        if (file_exists($f)) {
+          unlink($f);
+        }
+      }
+    }
+
+    /**
+     * Full pull against a Pantheon env, driven entirely by the generic fixture.
+     */
+    public function testRefreshUsesGenericConfigValues() {
+      // Mock shell_exec for SnapshotViaBackup's checkTerminus().
+      $mockShellExec = $this->mockBuiltIn('shell_exec');
+      $mockShellExec->expects(self::once())
+        ->with('which terminus')
+        ->willReturn('/usr/bin/terminus');
+
+      $opts = [
+        'env' => 'live',
+        'name' => 'nightly',
+        'element' => 'database',
+        'do-not-sanitize' => false,
+        'skip-download' => false,
+        'filename' => '__generic_refresh',
+      ];
+
+      $snapshotRefresh = $this->taskSnapshotRefresh($opts);
+      $mockBuilder = $this->mockCollectionBuilder();
+
+      $snapshotViaBackup = $this->taskSnapshotViaBackup($opts);
+      $dbSanitize = $this->taskDbSanitize($opts);
+      $snapshotPut = $this->taskSnapshotPut($opts);
+
+      // Stage 1: Pantheon backup path — note the GENERIC site 'acme-widgets'.
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('terminus backup:create acme-widgets.live --element=database --keep-for=1')
+        ->andReturn($this->mockTaskExec($snapshotViaBackup, 0, 'OK'));
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('terminus backup:list acme-widgets.live --format=json')
+        ->andReturn($this->mockTaskExec($snapshotViaBackup, 0, '{"1": {"file": "acme-widgets_99999_database.sql.gz"}}'));
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('terminus backup:get acme-widgets.live --file=acme-widgets_99999_database.sql.gz --to=__generic_refresh.tar.gz')
+        ->andReturn($this->mockTaskExec($snapshotViaBackup, 0, 'OK'));
+
+      $mockBuilder->shouldReceive('taskSnapshotViaBackup')
+        ->once()
+        ->andReturn($snapshotViaBackup);
+      $mockBuilder->shouldReceive('taskDbSanitize')
+        ->once()
+        ->andReturn($dbSanitize);
+      $mockBuilder->shouldReceive('taskSnapshotPut')
+        ->once()
+        ->andReturn($snapshotPut);
+
+      // Stage 2: the GENERIC sanitize command from the fixture.
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('drush sql:sanitize --sanitize-email=redacted@example.test')
+        ->andReturn($this->mockTaskExec($dbSanitize, 0, 'OK'));
+
+      // Stage 3: put into the GENERIC bucket 'nightly-dumps'.
+      $this->mockS3Client->shouldReceive('putObject')
+        ->once()
+        ->with([
+          'Bucket' => 'nightly-dumps',
+          'Key' => 'nightly/__generic_refresh.tar.gz',
+          'SourceFile' => '__generic_refresh.tar.gz',
+        ])
+        ->andReturn(new \Aws\Result());
+
+      $snapshotViaBackup->setBuilder($mockBuilder);
+      $dbSanitize->setBuilder($mockBuilder);
+      $snapshotPut->setBuilder($mockBuilder);
+      $snapshotRefresh->setBuilder($mockBuilder);
+
+      $result = $snapshotRefresh->run();
+      self::assertEquals(0, $result->getExitCode());
+    }
+
+  }
+}

--- a/tests/Robo/Task/Testor/SnapshotRefreshTest.php
+++ b/tests/Robo/Task/Testor/SnapshotRefreshTest.php
@@ -1,0 +1,343 @@
+<?php
+
+namespace PL\Tests\Robo\Task\Testor {
+
+  use PL\Robo\Task\Testor\SnapshotRefresh;
+
+  /**
+   * Tests for {@see SnapshotRefresh}, the generic producer orchestration
+   * (issue #27): (optionally) pull → sanitize → put, driven entirely by config.
+   *
+   * The chain is exercised with faked collaborators (a mocked collection
+   * builder returning real sub-tasks whose taskExec / S3 client are mocked),
+   * the same way {@see SnapshotGetTest} fakes SnapshotList.
+   *
+   * Genericness is proven by {@see SnapshotRefreshGenericConfigTest}, which runs
+   * the same chain against a second, deliberately non-performantlabs.com config
+   * fixture and asserts the fixture's own bucket/site reach the executed
+   * commands.
+   */
+  class SnapshotRefreshTest extends TestorTestCase {
+
+    public function tearDown(): void {
+      parent::tearDown();
+      foreach (['__test_refresh.sql', '__test_refresh.tar', '__test_refresh.tar.gz'] as $f) {
+        if (file_exists($f)) {
+          unlink($f);
+        }
+      }
+    }
+
+    /**
+     * Full pull path against a local (@self) env: SnapshotCreate (drush
+     * sql:dump + archive) → DbSanitize → SnapshotPut. All three stages run and
+     * the chain succeeds.
+     */
+    public function testFullPullLocalRunsCreateSanitizePut() {
+      /** @var \Consolidation\Config\Config $testorConfig */
+      $testorConfig = $this->getContainer()->get('testorConfig');
+      $testorConfig->set('sanitize.command', 'drush sql:sanitize');
+
+      $opts = [
+        'env' => '@self',
+        'name' => 'test',
+        'element' => 'database',
+        'do-not-sanitize' => false,
+        'skip-download' => false,
+        'filename' => '__test_refresh',
+      ];
+
+      $snapshotRefresh = $this->taskSnapshotRefresh($opts);
+      $mockBuilder = $this->mockCollectionBuilder();
+
+      // Sub-tasks the refresh chain will drive.
+      $snapshotCreate = $this->taskSnapshotCreate([...$opts, 'ispantheon' => false]);
+      $dbSanitize = $this->taskDbSanitize($opts);
+      $snapshotPut = $this->taskSnapshotPut($opts);
+
+      // Stage 1: local dump (drush sql:dump) — SnapshotCreate uses taskExec then
+      // taskArchivePack. We create a real dump file so ArchivePack has input.
+      file_put_contents('__test_refresh.sql', 'select 1+1;');
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('drush sql:dump > __test_refresh.sql')
+        ->andReturn($this->mockTaskExec($snapshotCreate, 0, 'OK'));
+      $mockBuilder->shouldReceive('taskArchivePack')
+        ->once()
+        ->andReturnUsing(fn(...$args) => $this->taskArchivePack(...$args));
+
+      // The refresh task itself drives sub-tasks via the mocked builder.
+      $mockBuilder->shouldReceive('taskSnapshotCreate')
+        ->once()
+        ->andReturn($snapshotCreate);
+      $mockBuilder->shouldReceive('taskDbSanitize')
+        ->once()
+        ->andReturn($dbSanitize);
+      $mockBuilder->shouldReceive('taskSnapshotPut')
+        ->once()
+        ->andReturn($snapshotPut);
+
+      // Stage 2: sanitize.
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('drush sql:sanitize')
+        ->andReturn($this->mockTaskExec($dbSanitize, 0, 'OK'));
+
+      // Stage 3: put — SnapshotPut uses the S3 client directly.
+      $this->mockS3Client->shouldReceive('putObject')
+        ->once()
+        ->with([
+          'Bucket' => 'snapshot',
+          'Key' => 'test/__test_refresh.tar.gz',
+          'SourceFile' => '__test_refresh.tar.gz',
+        ])
+        ->andReturn(new \Aws\Result());
+
+      $snapshotCreate->setBuilder($mockBuilder);
+      $dbSanitize->setBuilder($mockBuilder);
+      $snapshotPut->setBuilder($mockBuilder);
+      $snapshotRefresh->setBuilder($mockBuilder);
+
+      $result = $snapshotRefresh->run();
+      self::assertEquals(0, $result->getExitCode());
+    }
+
+    /**
+     * Full pull path against a Pantheon env: the backup-based path
+     * (SnapshotViaBackup: terminus backup:create/list/get) is used instead of a
+     * local dump, then sanitize → put. Proves the env branch selects the
+     * Pantheon puller.
+     */
+    public function testFullPullPantheonUsesViaBackup() {
+      /** @var \Consolidation\Config\Config $testorConfig */
+      $testorConfig = $this->getContainer()->get('testorConfig');
+      $testorConfig->set('sanitize.command', 'drush sql:sanitize');
+
+      // Mock shell_exec for SnapshotViaBackup's checkTerminus().
+      $mockShellExec = $this->mockBuiltIn('shell_exec');
+      $mockShellExec->expects(self::once())
+        ->with('which terminus')
+        ->willReturn('/usr/bin/terminus');
+
+      $opts = [
+        'env' => 'dev',
+        'name' => 'test',
+        'element' => 'database',
+        'do-not-sanitize' => false,
+        'skip-download' => false,
+        'filename' => '__test_refresh',
+      ];
+
+      $snapshotRefresh = $this->taskSnapshotRefresh($opts);
+      $mockBuilder = $this->mockCollectionBuilder();
+
+      $snapshotViaBackup = $this->taskSnapshotViaBackup($opts);
+      $dbSanitize = $this->taskDbSanitize($opts);
+      $snapshotPut = $this->taskSnapshotPut($opts);
+
+      // Stage 1: Pantheon backup path — three terminus commands.
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('terminus backup:create performant-labs.dev --element=database --keep-for=1')
+        ->andReturn($this->mockTaskExec($snapshotViaBackup, 0, 'OK'));
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('terminus backup:list performant-labs.dev --format=json')
+        ->andReturn($this->mockTaskExec($snapshotViaBackup, 0, '{"1": {"file": "performant-labs_11111_database.sql.gz"}}'));
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('terminus backup:get performant-labs.dev --file=performant-labs_11111_database.sql.gz --to=__test_refresh.tar.gz')
+        ->andReturn($this->mockTaskExec($snapshotViaBackup, 0, 'OK'));
+
+      $mockBuilder->shouldReceive('taskSnapshotViaBackup')
+        ->once()
+        ->andReturn($snapshotViaBackup);
+      $mockBuilder->shouldReceive('taskDbSanitize')
+        ->once()
+        ->andReturn($dbSanitize);
+      $mockBuilder->shouldReceive('taskSnapshotPut')
+        ->once()
+        ->andReturn($snapshotPut);
+
+      // Stage 2: sanitize.
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('drush sql:sanitize')
+        ->andReturn($this->mockTaskExec($dbSanitize, 0, 'OK'));
+
+      // Stage 3: put.
+      $this->mockS3Client->shouldReceive('putObject')
+        ->once()
+        ->with([
+          'Bucket' => 'snapshot',
+          'Key' => 'test/__test_refresh.tar.gz',
+          'SourceFile' => '__test_refresh.tar.gz',
+        ])
+        ->andReturn(new \Aws\Result());
+
+      $snapshotViaBackup->setBuilder($mockBuilder);
+      $dbSanitize->setBuilder($mockBuilder);
+      $snapshotPut->setBuilder($mockBuilder);
+      $snapshotRefresh->setBuilder($mockBuilder);
+
+      $result = $snapshotRefresh->run();
+      self::assertEquals(0, $result->getExitCode());
+    }
+
+    /**
+     * Skip-download path: with --skip-download, the pull stage must NOT run at
+     * all (no terminus, no drush sql:dump) — only sanitize → put run against the
+     * already-local dump.
+     *
+     * The decisive guarantee is that NO pull sub-task is invoked: neither
+     * taskSnapshotViaBackup nor taskSnapshotCreate is set up on the mock, so if
+     * the code tried to pull, Mockery would fail the test on the unexpected
+     * call.
+     */
+    public function testSkipDownloadRunsOnlySanitizeAndPut() {
+      /** @var \Consolidation\Config\Config $testorConfig */
+      $testorConfig = $this->getContainer()->get('testorConfig');
+      $testorConfig->set('sanitize.command', 'drush sql:sanitize');
+
+      $opts = [
+        'env' => '@self',
+        'name' => 'test',
+        'element' => 'database',
+        'do-not-sanitize' => false,
+        'skip-download' => true,
+        'filename' => '__test_refresh',
+      ];
+
+      $snapshotRefresh = $this->taskSnapshotRefresh($opts);
+      $mockBuilder = $this->mockCollectionBuilder();
+
+      $dbSanitize = $this->taskDbSanitize($opts);
+      $snapshotPut = $this->taskSnapshotPut($opts);
+
+      // NO taskSnapshotViaBackup / taskSnapshotCreate expectations: any pull
+      // attempt is an unexpected call and fails the test.
+      $mockBuilder->shouldReceive('taskDbSanitize')
+        ->once()
+        ->andReturn($dbSanitize);
+      $mockBuilder->shouldReceive('taskSnapshotPut')
+        ->once()
+        ->andReturn($snapshotPut);
+
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('drush sql:sanitize')
+        ->andReturn($this->mockTaskExec($dbSanitize, 0, 'OK'));
+
+      $this->mockS3Client->shouldReceive('putObject')
+        ->once()
+        ->with([
+          'Bucket' => 'snapshot',
+          'Key' => 'test/__test_refresh.tar.gz',
+          'SourceFile' => '__test_refresh.tar.gz',
+        ])
+        ->andReturn(new \Aws\Result());
+
+      $dbSanitize->setBuilder($mockBuilder);
+      $snapshotPut->setBuilder($mockBuilder);
+      $snapshotRefresh->setBuilder($mockBuilder);
+
+      $result = $snapshotRefresh->run();
+      self::assertEquals(0, $result->getExitCode());
+    }
+
+    /**
+     * Short-circuit: if SANITIZE fails, PUT must NEVER run — pushing an
+     * unsanitized dump to storage is the exact failure this guards against.
+     *
+     * The decisive guarantee: taskSnapshotPut is asserted `never()`, and the S3
+     * client's putObject has no expectation, so any push after a failed
+     * sanitize fails the test.
+     *
+     * Mutation evidence (documented in the PR): removing the
+     * `if (!$result->wasSuccessful()) return $result;` guard after the sanitize
+     * stage in SnapshotRefresh::run() makes this test go RED (taskSnapshotPut is
+     * then invoked); restoring it makes it GREEN.
+     */
+    public function testSanitizeFailureShortCircuitsPut() {
+      /** @var \Consolidation\Config\Config $testorConfig */
+      $testorConfig = $this->getContainer()->get('testorConfig');
+      $testorConfig->set('sanitize.command', 'drush sql:sanitize');
+
+      $opts = [
+        'env' => '@self',
+        'name' => 'test',
+        'element' => 'database',
+        'do-not-sanitize' => false,
+        'skip-download' => true,
+        'filename' => '__test_refresh',
+      ];
+
+      $snapshotRefresh = $this->taskSnapshotRefresh($opts);
+      $mockBuilder = $this->mockCollectionBuilder();
+
+      $dbSanitize = $this->taskDbSanitize($opts);
+
+      $mockBuilder->shouldReceive('taskDbSanitize')
+        ->once()
+        ->andReturn($dbSanitize);
+      // Put must never be constructed nor run.
+      $mockBuilder->shouldReceive('taskSnapshotPut')
+        ->never();
+
+      // Sanitize fails.
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('drush sql:sanitize')
+        ->andReturn($this->mockTaskExec(new \Robo\Result($dbSanitize, 1, 'SANITIZE BLEW UP')));
+
+      // No putObject expectation: a push here is an unexpected call.
+
+      $dbSanitize->setBuilder($mockBuilder);
+      $snapshotRefresh->setBuilder($mockBuilder);
+
+      $result = $snapshotRefresh->run();
+      self::assertEquals(1, $result->getExitCode());
+      self::assertStringContainsString('SANITIZE BLEW UP', $result->getMessage());
+    }
+
+    /**
+     * Short-circuit: if the PULL stage fails, neither sanitize nor put runs.
+     */
+    public function testPullFailureShortCircuitsRest() {
+      $opts = [
+        'env' => '@self',
+        'name' => 'test',
+        'element' => 'database',
+        'do-not-sanitize' => false,
+        'skip-download' => false,
+        'filename' => '__test_refresh',
+      ];
+
+      $snapshotRefresh = $this->taskSnapshotRefresh($opts);
+      $mockBuilder = $this->mockCollectionBuilder();
+
+      $snapshotCreate = $this->taskSnapshotCreate([...$opts, 'ispantheon' => false]);
+
+      // Pull (local dump) fails on the very first command.
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('drush sql:dump > __test_refresh.sql')
+        ->andReturn($this->mockTaskExec(new \Robo\Result($snapshotCreate, 1, 'DUMP FAILED')));
+
+      $mockBuilder->shouldReceive('taskSnapshotCreate')
+        ->once()
+        ->andReturn($snapshotCreate);
+      // Neither sanitize nor put may run.
+      $mockBuilder->shouldReceive('taskDbSanitize')->never();
+      $mockBuilder->shouldReceive('taskSnapshotPut')->never();
+
+      $snapshotCreate->setBuilder($mockBuilder);
+      $snapshotRefresh->setBuilder($mockBuilder);
+
+      $result = $snapshotRefresh->run();
+      self::assertEquals(1, $result->getExitCode());
+      self::assertStringContainsString('DUMP FAILED', $result->getMessage());
+    }
+
+  }
+}


### PR DESCRIPTION
## What

Adds `snapshot:refresh` — the generic, config-driven **producer** orchestration from epic #24. It chains the existing primitives into one repeatable command:

```
(optional) pull  →  sanitize  →  put
```

- **`SnapshotRefresh`** task drives `SnapshotViaBackup` / `SnapshotCreate`, `DbSanitize`, and `SnapshotPut` through `collectionBuilder()->taskX()->run()` (the same idiom as `SnapshotGet`), inspecting each `Result` and **short-circuiting on failure** — a failed sanitize never pushes an unsanitized dump.
- **`snapshot:refresh`** command with **`--skip-download`** to re-sanitize/re-push an already-local dump without hitting the source environment again. The Pantheon-vs-local puller is chosen by env exactly as `snapshot:create` already does.

## No UUID step — by design

Per **#25** (PR #30), Drupal site-UUID normalization (`DbUuidNormalize`) is a **consumer-side (restore-time), per-target** concern: the correct UUID is a property of the target environment, not of the snapshot, since one snapshot legitimately restores into many differently-UUID'd targets. The producer therefore does **not** call `DbUuidNormalize` — that is the consumer command's job (#28). Issue #27's text lists a UUID step, but it predates #25's settled design; adding it here would build a parallel, conflicting path.

## Genericness proven, not asserted

Nothing about performantlabs.com is hardcoded. A second, deliberately fictional fixture — **`.testor_generic_test.yml`** (site `acme-widgets`, bucket `nightly-dumps`, a custom sanitize command) — plus **`SnapshotRefreshGenericConfigTest`** assert that the *fixture's own* site/bucket/sanitize values reach the executed commands and the S3 client.

## Tests

Faked collaborators (mocked collection builder + mocked S3 client), following `SnapshotGetTest` / `TestorTestCase` conventions:

- full local-pull chain (create → sanitize → put)
- Pantheon backup pull (`SnapshotViaBackup` → sanitize → put)
- **skip-download** — the pull stage never runs (no pull sub-task is set up; any pull attempt fails the test)
- **sanitize-failure short-circuit** — `taskSnapshotPut` asserted `never()`; mutation-tested (removing the guard turns it RED, restoring it GREEN)
- pull-failure short-circuit — neither sanitize nor put runs
- generic-config run

Full suite green (49 tests, 237 assertions); PHPStan clean (58 files).

Addresses #27. Part of epic #24.