### PR TITLE
feat(snapshot): snapshot:restore consumer command

### DIFF
--- a/src/Robo/Plugin/Commands/TestorCommands.php
+++ b/src/Robo/Plugin/Commands/TestorCommands.php
@@ -199,6 +199,35 @@ class TestorCommands extends \Robo\Tasks implements TestorConfigAwareInterface {
   }
 
   /**
+   * Restore a snapshot into the target database.
+   *
+   * Generic consumer command: pulls a snapshot from the configured storage,
+   * imports it into the target database, then reconciles the restored Drupal
+   * site uuid with the target environment (a no-op when no target uuid is
+   * resolvable). Everything is driven by `.testor.yml` (bucket, `sql.command`,
+   * `uuid.*`) — no project-specific values are baked in.
+   *
+   * @param array $opts
+   * @option $name Name of the snapshot, can be either exact name, or prefix
+   * like "developer" or "preview" — the folder the snapshot lives under.
+   * @option $output Output file. If not specified, original file name is kept.
+   * @option $element Element to restore (code, database, files).
+   * @option $snapshot Exact name of a specific snapshot to restore (as shown
+   * in the "Name" column of `snapshot:list`). When omitted, the latest
+   * snapshot is restored. When set, it must match exactly, or the command
+   * fails — it never silently falls back to the latest.
+   * @option $uuid Target Drupal site uuid to normalize to after import. When
+   * omitted, `uuid.value` from config is used; if neither is set, the uuid
+   * normalization step is skipped.
+   * @return Result
+   */
+  public function snapshotRestore(array $opts = ['name' => '', 'output|o' => null, 'element' => 'database', 'snapshot' => null, 'uuid' => null]): Result {
+    $this->normalizeElement($opts);
+    $result = $this->collectionBuilder()->taskSnapshotRestore($opts)->run();
+    return $this->echo($result);
+  }
+
+  /**
    * Delete snapshot(s) from the storage.
    *
    * @option $name Name or prefix of snapshot(s)

--- a/src/Robo/Task/Testor/SnapshotRestore.php
+++ b/src/Robo/Task/Testor/SnapshotRestore.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace PL\Robo\Task\Testor;
+
+use PL\Robo\Common\TestorConfigAwareTrait;
+use PL\Robo\Contract\TestorConfigAwareInterface;
+use Robo\Common\BuilderAwareTrait;
+
+/**
+ * Generic consumer orchestration: pull a snapshot from the storage and
+ * restore it into the target database.
+ *
+ * Chains three existing primitives, in this order:
+ *
+ *   1. {@see SnapshotGet}       — download the snapshot object. With no pin
+ *                                 the latest (newest-dated) object is fetched
+ *                                 (issue #26 default); with `snapshot` set,
+ *                                 that exact object is fetched instead.
+ *   2. {@see SnapshotImport}    — unpack it and load the SQL into the target
+ *                                 database (`sql.command < file.sql`).
+ *   3. {@see DbUuidNormalize}   — reconcile the restored Drupal `system.site`
+ *                                 uuid with the TARGET environment's uuid.
+ *
+ * Ordering is load-bearing. UUID normalization MUST run AFTER the import: the
+ * import overwrites the target database wholesale, so normalizing before it
+ * would massage a uuid that the import then clobbers with the snapshot's
+ * (prod's) uuid — leaving the target unimportable, the exact failure #25's
+ * design set out to prevent. Per #25, the correct uuid belongs to the target,
+ * not the snapshot, so the reconciliation is a consumer-side (restore-time),
+ * per-target step — which is why it lives here and not in the producer.
+ *
+ * Everything is config-driven (bucket, `sql.command`, `uuid.*`) — no
+ * project-specific values are baked in. Like {@see DbUuidNormalize} itself,
+ * step 3 is a no-op unless a target uuid is resolvable (via `--uuid` or
+ * `uuid.value`), so a non-Drupal or uuid-agnostic project restores cleanly
+ * with steps 1–2 only.
+ */
+class SnapshotRestore extends TestorTask
+  implements TestorConfigAwareInterface {
+  use BuilderAwareTrait;
+  use TestorConfigAwareTrait;
+
+  protected string $name;
+  protected string $element;
+  protected ?string $outputFilename;
+  protected ?string $snapshot;
+  protected ?string $uuid;
+  protected bool $gzip;
+
+  public function __construct(array $args) {
+    parent::__construct();
+    $this->name = $args['name'];
+    $this->element = $args['element'];
+    $this->outputFilename = $args['output'] ?? null;
+    // Optional version pin, forwarded to SnapshotGet. Null => latest.
+    $this->snapshot = $args['snapshot'] ?? null;
+    // Optional target uuid, forwarded to DbUuidNormalize. Null => the task
+    // falls back to `uuid.value` config, and skips if neither is set.
+    $this->uuid = $args['uuid'] ?? null;
+    $this->gzip = $args['gzip'] ?? true;
+  }
+
+  public function run(): \Robo\Result {
+    $task = $this->collectionBuilder();
+
+    // 1. Download (latest, or the pinned snapshot).
+    $task
+      ->taskSnapshotGet([
+        'name' => $this->name,
+        'element' => $this->element,
+        'output' => $this->outputFilename,
+        'snapshot' => $this->snapshot,
+      ])
+      // SnapshotGet returns the concrete downloaded filename; hand it to
+      // SnapshotImport (whose filename() setter strips the extension).
+      ->storeState('filename', 'filename')
+      // 2. Load it into the target database.
+      ->taskSnapshotImport(['gzip' => $this->gzip])
+      ->deferTaskConfiguration('filename', 'filename')
+      // 3. Reconcile the target's Drupal site uuid — AFTER the import, since
+      //    the import replaces the database the previous step would have
+      //    massaged. A no-op when no target uuid is resolvable.
+      ->taskDbUuidNormalize(['uuid' => $this->uuid]);
+
+    return $task->run();
+  }
+
+}

--- a/src/Robo/Task/Testor/Tasks.php
+++ b/src/Robo/Task/Testor/Tasks.php
@@ -58,6 +58,10 @@ namespace PL\Robo\Task\Testor {
       return $this->task(SnapshotGet::class, $opts);
     }
 
+    protected function taskSnapshotRestore(array $opts): \Robo\Collection\CollectionBuilder {
+      return $this->task(SnapshotRestore::class, $opts);
+    }
+
     protected function taskTugboatPreviewCreate(array $opts): \Robo\Collection\CollectionBuilder {
       return $this->task(TugboatPreviewCreate::class, $opts);
     }

--- a/tests/Robo/Task/Testor/SnapshotRestoreTest.php
+++ b/tests/Robo/Task/Testor/SnapshotRestoreTest.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace PL\Tests\Robo\Task\Testor;
+
+use PL\Robo\Task\Testor\SnapshotRestore;
+
+/**
+ * Tests for {@see SnapshotRestore}, the generic consumer orchestration
+ * (issue #28): download a snapshot, import it, then normalize the target
+ * Drupal site uuid.
+ *
+ * SnapshotRestore chains three sub-tasks through a collection builder:
+ *
+ *   taskSnapshotGet -> taskSnapshotImport -> taskDbUuidNormalize
+ *
+ * The tests swap that builder for a Mockery mock (the same technique
+ * SnapshotGetTest uses to intercept the internal taskSnapshotList call), which
+ * lets us assert three things that matter for the acceptance criteria:
+ *
+ *   1. The version-pin option is forwarded to SnapshotGet — null => latest,
+ *      an explicit name => that pinned snapshot.
+ *   2. The resolved target uuid actually reaches DbUuidNormalize.
+ *   3. The chain ORDER is import-then-normalize, never the reverse — the
+ *      mutation the ordering guards against (normalize before import) would be
+ *      caught here.
+ */
+class SnapshotRestoreTest extends TestorTestCase {
+
+  /**
+   * Build a fluent mock collection builder whose taskX() methods each return
+   * the builder (so the fluent chain in SnapshotRestore::run() works) and whose
+   * run() reports success. Every task expectation is registered `->ordered()`
+   * so Mockery fails if the tasks are chained in the wrong sequence.
+   *
+   * @return \Mockery\MockInterface|\Robo\Collection\CollectionBuilder
+   */
+  private function mockChainBuilder() {
+    $mockBuilder = $this->mockCollectionBuilder();
+    // storeState / deferTaskConfiguration are pass-through links in the chain.
+    $mockBuilder->shouldReceive('storeState')->andReturn($mockBuilder);
+    $mockBuilder->shouldReceive('deferTaskConfiguration')->andReturn($mockBuilder);
+    return $mockBuilder;
+  }
+
+  /**
+   * No `--snapshot` selector: SnapshotGet must be handed a null pin (which it
+   * interprets as "latest"), and the full import-then-normalize chain must run.
+   */
+  public function testRestoreDefaultForwardsLatestAndRunsFullChain() {
+    $uuid = 'a0030de7-5e41-4016-908d-3e0845e30acb';
+    $restore = $this->taskSnapshotRestore([
+      'name' => 'test',
+      'element' => 'database',
+      'output' => 'test.sql.gz',
+      'uuid' => $uuid,
+    ]);
+
+    $mockBuilder = $this->mockChainBuilder();
+
+    // 1. Download — the pin must be forwarded as null (=> latest).
+    $mockBuilder->shouldReceive('taskSnapshotGet')
+      ->once()
+      ->ordered()
+      ->with(\Mockery::on(fn($opts) => $opts['name'] === 'test'
+        && $opts['element'] === 'database'
+        && $opts['output'] === 'test.sql.gz'
+        && $opts['snapshot'] === null))
+      ->andReturn($mockBuilder);
+    // 2. Import — AFTER download.
+    $mockBuilder->shouldReceive('taskSnapshotImport')
+      ->once()
+      ->ordered()
+      ->andReturn($mockBuilder);
+    // 3. UUID normalize — AFTER import — with the caller's uuid.
+    $mockBuilder->shouldReceive('taskDbUuidNormalize')
+      ->once()
+      ->ordered()
+      ->with(['uuid' => $uuid])
+      ->andReturn($mockBuilder);
+
+    $mockBuilder->shouldReceive('run')
+      ->once()
+      ->andReturn(new \Robo\Result($restore, 0, 'OK'));
+
+    $restore->setBuilder($mockBuilder);
+
+    $result = $restore->run();
+    self::assertEquals(0, $result->getExitCode());
+  }
+
+  /**
+   * `--snapshot=<name>`: the exact pin must be forwarded to SnapshotGet, not
+   * swallowed — this is what makes `snapshot:restore --snapshot=X` restore X
+   * rather than the latest.
+   */
+  public function testRestorePinnedForwardsSnapshotSelector() {
+    $pin = 'test/performant-labs_1111_database.sql.gz';
+    $restore = $this->taskSnapshotRestore([
+      'name' => 'test',
+      'element' => 'database',
+      'output' => 'test.sql.gz',
+      'snapshot' => $pin,
+    ]);
+
+    $mockBuilder = $this->mockChainBuilder();
+
+    $mockBuilder->shouldReceive('taskSnapshotGet')
+      ->once()
+      ->with(\Mockery::on(fn($opts) => $opts['snapshot'] === $pin))
+      ->andReturn($mockBuilder);
+    $mockBuilder->shouldReceive('taskSnapshotImport')->once()->andReturn($mockBuilder);
+    $mockBuilder->shouldReceive('taskDbUuidNormalize')->once()->andReturn($mockBuilder);
+    $mockBuilder->shouldReceive('run')
+      ->once()
+      ->andReturn(new \Robo\Result($restore, 0, 'OK'));
+
+    $restore->setBuilder($mockBuilder);
+
+    $result = $restore->run();
+    self::assertEquals(0, $result->getExitCode());
+  }
+
+  /**
+   * The uuid the caller passes must be the uuid that reaches DbUuidNormalize
+   * (not dropped, not defaulted away). Distinct value from the other tests so a
+   * "always passes the same uuid" bug can't pass by luck.
+   */
+  public function testRestoreForwardsTargetUuidToNormalize() {
+    $uuid = '5d00dfdf-9614-48ed-91ba-d902cbb96b05';
+    $restore = $this->taskSnapshotRestore([
+      'name' => 'test',
+      'element' => 'database',
+      'uuid' => $uuid,
+    ]);
+
+    $mockBuilder = $this->mockChainBuilder();
+    $mockBuilder->shouldReceive('taskSnapshotGet')->once()->andReturn($mockBuilder);
+    $mockBuilder->shouldReceive('taskSnapshotImport')->once()->andReturn($mockBuilder);
+    $mockBuilder->shouldReceive('taskDbUuidNormalize')
+      ->once()
+      ->with(['uuid' => $uuid])
+      ->andReturn($mockBuilder);
+    $mockBuilder->shouldReceive('run')
+      ->once()
+      ->andReturn(new \Robo\Result($restore, 0, 'OK'));
+
+    $restore->setBuilder($mockBuilder);
+
+    $result = $restore->run();
+    self::assertEquals(0, $result->getExitCode());
+  }
+
+  /**
+   * MUTATION GUARD — chain ordering.
+   *
+   * This test asserts the import-before-normalize order via strict Mockery
+   * `->ordered()` sequencing. It exists to catch the specific regression where
+   * a maintainer reorders SnapshotRestore::run() to normalize the uuid BEFORE
+   * the import — which is silently wrong, because the import replaces the whole
+   * database and would clobber the just-normalized uuid with the snapshot's
+   * (prod's) uuid, re-introducing the exact "site uuid mismatch" failure #25's
+   * design fixed.
+   *
+   * Proven to bite: with SnapshotRestore chaining
+   * taskDbUuidNormalize BEFORE taskSnapshotImport, Mockery raises
+   * "method called out of order" and this test fails. With the correct order
+   * (import then normalize) it passes. See the handoff for the recorded
+   * mutation run.
+   */
+  public function testChainNormalizesAfterImportNotBefore() {
+    $uuid = 'a0030de7-5e41-4016-908d-3e0845e30acb';
+    $restore = $this->taskSnapshotRestore([
+      'name' => 'test',
+      'element' => 'database',
+      'uuid' => $uuid,
+    ]);
+
+    $mockBuilder = $this->mockChainBuilder();
+
+    // Strict global ordering: get(1) -> import(2) -> normalize(3).
+    $mockBuilder->shouldReceive('taskSnapshotGet')->once()->globally()->ordered()->andReturn($mockBuilder);
+    $mockBuilder->shouldReceive('taskSnapshotImport')->once()->globally()->ordered()->andReturn($mockBuilder);
+    $mockBuilder->shouldReceive('taskDbUuidNormalize')->once()->globally()->ordered()->andReturn($mockBuilder);
+    $mockBuilder->shouldReceive('run')->once()->andReturn(new \Robo\Result($restore, 0, 'OK'));
+
+    $restore->setBuilder($mockBuilder);
+
+    $result = $restore->run();
+    self::assertEquals(0, $result->getExitCode());
+  }
+
+  /**
+   * A failing sub-task (here the run() of the chain) propagates its non-zero
+   * exit code out of SnapshotRestore, so the operator sees the failure rather
+   * than a false success.
+   */
+  public function testRestorePropagatesChainFailure() {
+    $restore = $this->taskSnapshotRestore([
+      'name' => 'test',
+      'element' => 'database',
+      'uuid' => 'a0030de7-5e41-4016-908d-3e0845e30acb',
+    ]);
+
+    $mockBuilder = $this->mockChainBuilder();
+    $mockBuilder->shouldReceive('taskSnapshotGet')->once()->andReturn($mockBuilder);
+    $mockBuilder->shouldReceive('taskSnapshotImport')->once()->andReturn($mockBuilder);
+    $mockBuilder->shouldReceive('taskDbUuidNormalize')->once()->andReturn($mockBuilder);
+    $mockBuilder->shouldReceive('run')
+      ->once()
+      ->andReturn(new \Robo\Result($restore, 1, 'DOWNLOAD BLEW UP'));
+
+    $restore->setBuilder($mockBuilder);
+
+    $result = $restore->run();
+    self::assertEquals(1, $result->getExitCode());
+    self::assertStringContainsString('DOWNLOAD BLEW UP', $result->getMessage());
+  }
+
+}


### PR DESCRIPTION
## What

Adds `snapshot:restore` — the generic consumer command from epic #24. It chains the three existing primitives into a one-shot restore:

```
SnapshotGet -> SnapshotImport -> DbUuidNormalize
```

- **Version pinning (#26).** No argument restores the latest snapshot (unchanged default); `snapshot:restore --snapshot=<name>` restores that exact one. The `--snapshot` pin is forwarded straight through to `SnapshotGet`.
- **UUID normalization (#25).** `DbUuidNormalize` runs **after** the import, per #25's settled design: the correct UUID belongs to the *target* environment, not the snapshot, so reconciliation is consumer-side and per-target. The target UUID comes from `--uuid`, falling back to `uuid.value` in config; if neither is set the step is a no-op (uuid-agnostic projects restore cleanly with get+import only).

## Ordering is load-bearing

The import replaces the target database wholesale. Normalizing the site UUID *before* the import would massage a value the import then clobbers with the snapshot's (prod's) UUID — re-introducing the exact "site UUID mismatch" failure #25 fixed. A dedicated **mutation-guard test** (`testChainNormalizesAfterImportNotBefore`) enforces import-before-normalize via strict Mockery ordering. Verified it bites: reordering the chain to normalize-first makes that test fail with `Mockery InvalidOrderException: taskSnapshotImport called out of order`.

## Generic

Everything is config-driven (`s3.bucket`, `sql.command`, `uuid.*`) — no performantlabs.com-specific values in the code. Proven against `.testor_test.yml`'s fixture shape, which is itself already generic (its `pantheon.site` / `s3.bucket` are ordinary config, and it carries no `uuid.*`, so the uuid step correctly no-ops there).

## Tests

`SnapshotRestoreTest` (5 new tests, all task-level, mocking the collection builder the same way `SnapshotGetTest` does):

- no-arg path forwards a null pin (=> latest) and runs the full get->import->normalize chain;
- `--snapshot=<name>` forwards the exact pin;
- the caller's target UUID reaches `DbUuidNormalize`;
- **mutation guard**: import strictly precedes normalize;
- a failing sub-task propagates its non-zero exit out of the command.

Full suite: 48 tests / 206 assertions green (was 43/180 post-#29/#30). `phpstan analyze tests/ src/` clean.

## Real-run note

A true end-to-end restore (download a real S3 object -> import into a scratch DB -> `drush config:set`) is **not headlessly feasible** in this environment: it needs real credentials for the `snapshot` S3 bucket and a live Drupal/drush target, neither of which is available here. What *was* verified live: running `snapshot:restore` against the fixture config drives the real chain into `SnapshotGet::__construct` (the first real task) before failing only at `S3Client` construction on the `**DUMMY**` placeholder credentials — proving the orchestration wiring executes, not just the mocked units. The command, its four options, and its help all register correctly (`testor snapshot:restore --help`).

---

Addresses #28. Part of epic #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)