### PR TITLE
fix(snapshot:refresh): stop pushing unsanitized prod dump (issue #33)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,22 @@
+Testor 1.11.1, 2026-08-18
+-------------------------
+Changes since 1.11.0:
+- SECURITY (issue #33): snapshot:refresh no longer pushes an unsanitized
+  production dump. The chain now imports the pulled dump into the database,
+  sanitizes THAT database in place, and re-exports it before pushing
+  (pull -> import -> sanitize -> re-export -> put), instead of sanitizing an
+  unrelated already-connected local DB while pushing the raw download. This
+  applies to both the Pantheon-backup and the local/@self pull paths, which had
+  the identical dump-before-sanitize flaw. The chain short-circuits on a failed
+  import or re-export, so no unsanitized/corrupted file can reach storage. Uses
+  the existing sql.command (import) and sqldump.command (re-export) config keys;
+  no new configuration is required.
+- Fixed ArchivePack to evict any per-process Phar registration for the target
+  .tar.gz before recreating it, so packing the same archive twice within one
+  run (as the hardened snapshot:refresh now does) no longer fails with "a phar
+  with that name already exists".
+
+
 Testor 1.11.0, 2026-08-16
 -------------------------
 Changes since 1.10.3:

--- a/src/Robo/Task/Testor/ArchivePack.php
+++ b/src/Robo/Task/Testor/ArchivePack.php
@@ -26,6 +26,19 @@ class ArchivePack extends TestorTask {
   public function run(): \Robo\Result {
     try {
       $archive = $this->archive;
+
+      // Evict any Phar the current PHP process has already cached for the
+      // target "$archive.tar.gz" path. Phar keeps a per-process registry keyed
+      // by filename, and compress() refuses to overwrite a path that is still
+      // registered ("a phar with that name already exists"). This bites within
+      // a single `snapshot:refresh` run: the pull packs "$archive.tar.gz", the
+      // import unpacks it (registering that path), and the re-export then packs
+      // the SAME path again — which would fail without this eviction. Deleting
+      // the archive here is safe because we are about to recreate it.
+      if (file_exists("$archive.tar.gz")) {
+        \Phar::unlinkArchive("$archive.tar.gz");
+      }
+
       $phar = new \PharData("$archive.tar");
       foreach ($this->files as $file) {
         $phar->addFile($file);

--- a/src/Robo/Task/Testor/SnapshotRefresh.php
+++ b/src/Robo/Task/Testor/SnapshotRefresh.php
@@ -12,10 +12,28 @@ use Robo\Result;
  * source environment, sanitize it, then push it to the configured storage.
  *
  * This is the producer half of the epic-#24 pipeline. It chains the existing
- * primitives — {@see SnapshotViaBackup}/{@see SnapshotCreate}, {@see DbSanitize},
- * {@see SnapshotPut} — into one repeatable, config-driven command. Everything
- * (Pantheon site, sanitization rules, bucket) comes from `.testor.yml`; nothing
- * is hardcoded to any particular project.
+ * primitives — {@see SnapshotViaBackup}/{@see SnapshotCreate}, {@see SnapshotImport},
+ * {@see DbSanitize}, {@see SnapshotCreate} (re-export), {@see SnapshotPut} — into
+ * one repeatable, config-driven command. Everything (Pantheon site, sanitization
+ * rules, bucket) comes from `.testor.yml`; nothing is hardcoded to any particular
+ * project.
+ *
+ * SECURITY-CRITICAL ORDERING (issue #33). The pulled dump is raw production data.
+ * `drush sql:sanitize` only ever mutates the database drush is *connected* to — it
+ * cannot reach into a `.sql`/`.tar.gz` file on disk. So a chain of
+ * pull → sanitize → put sanitizes some unrelated already-connected local DB and
+ * then pushes the UNTOUCHED raw download — leaking every prod email/password hash.
+ * The only correct order is therefore:
+ *
+ *   pull → IMPORT the pulled dump into the DB → sanitize THAT DB → RE-EXPORT the
+ *   now-sanitized DB back into the file → put.
+ *
+ * The import (`sql.command < file.sql`, via {@see SnapshotImport}) and re-export
+ * (`sqldump.command > file.sql` + pack, via {@see SnapshotCreate}'s local branch)
+ * are the two stages that make the sanitize operate on — and the push carry — the
+ * pulled data. This holds identically for the Pantheon and the local/`@self`
+ * puller: both land a raw `.tar.gz` that is only sanitized once it has been
+ * imported, sanitized in place, and re-exported.
  *
  * Deliberately NO UUID-normalization step. Per issue #25's settled design, the
  * Drupal site-UUID massaging ({@see DbUuidNormalize}) is a CONSUMER-side
@@ -26,8 +44,9 @@ use Robo\Result;
  * command (issue #28) instead.
  *
  * The chain short-circuits: each stage's result is checked, and a failure
- * returns immediately so that no later stage runs (e.g. a failed sanitize must
- * never push an unsanitized dump to storage).
+ * returns immediately so that no later stage runs. A failed pull, import,
+ * sanitize, OR re-export must never let an unsanitized (or corrupted) file reach
+ * {@see SnapshotPut}.
  *
  * Mirrors {@see SnapshotGet}'s orchestration style: it drives sub-tasks through
  * `collectionBuilder()->taskX()->run()` and inspects each Result, rather than
@@ -69,14 +88,40 @@ class SnapshotRefresh extends TestorTask implements TestorConfigAwareInterface {
       }
     }
 
-    // Stage 2: sanitize the (local) dump.
+    // Stage 2: import the pulled RAW dump into the database, so that the
+    // sanitize in stage 3 has real data to act on. Without this, sanitize
+    // mutates some unrelated already-connected DB and the raw download is
+    // pushed untouched (issue #33). `gzip => true`: both pullers land a
+    // `.tar.gz` (Pantheon's `backup:get --to=…tar.gz`; the local puller packs
+    // its `.sql` into `…tar.gz`), which SnapshotImport unpacks before loading.
+    $result = $this->collectionBuilder()
+      ->taskSnapshotImport([...$opts, 'gzip' => true])
+      ->run();
+    if (!$result->wasSuccessful()) {
+      // Short-circuit: a failed import must not let a raw dump reach the push.
+      return $result;
+    }
+
+    // Stage 3: sanitize the just-imported database in place.
     $result = $this->collectionBuilder()->taskDbSanitize($opts)->run();
     if (!$result->wasSuccessful()) {
       // Short-circuit: never push an unsanitized dump.
       return $result;
     }
 
-    // Stage 3: push the sanitized result to the configured storage.
+    // Stage 4: re-export the now-sanitized database back into the file that
+    // stage 5 pushes. Reuses SnapshotCreate's local branch
+    // (`sqldump.command > file.sql`, then pack to `file.tar.gz`). Without this,
+    // the file on disk is still the raw pre-sanitize dump from stage 1.
+    $result = $this->collectionBuilder()
+      ->taskSnapshotCreate([...$opts, 'ispantheon' => false])
+      ->run();
+    if (!$result->wasSuccessful()) {
+      // Short-circuit: a failed/partial re-export must not reach the push.
+      return $result;
+    }
+
+    // Stage 5: push the sanitized, re-exported result to the configured storage.
     return $this->collectionBuilder()->taskSnapshotPut($opts)->run();
   }
 

--- a/tests/Robo/Task/Testor/SnapshotRefreshGenericConfigTest.php
+++ b/tests/Robo/Task/Testor/SnapshotRefreshGenericConfigTest.php
@@ -40,9 +40,20 @@ namespace PL\Tests\Robo\Task\Testor {
 
     public function tearDown(): void {
       parent::tearDown();
-      foreach (['__generic_refresh.tar.gz'] as $f) {
+      foreach ([
+        '__generic_refresh.sql',
+        '__generic_refresh.tar',
+        '__generic_refresh.tar.gz',
+      ] as $f) {
         if (file_exists($f)) {
-          unlink($f);
+          // Evict the per-process Phar registration for the .tar.gz while the
+          // file still exists (see SnapshotRefreshTest::tearDown for why).
+          if (str_ends_with($f, '.tar.gz')) {
+            \Phar::unlinkArchive($f);
+          }
+          else {
+            unlink($f);
+          }
         }
       }
     }
@@ -66,11 +77,25 @@ namespace PL\Tests\Robo\Task\Testor {
         'filename' => '__generic_refresh',
       ];
 
+      // Seed the raw download the Pantheon puller would produce, so the import
+      // stage has a real archive to unpack.
+      $base = '__generic_refresh';
+      file_put_contents("$base.sql", 'raw dump');
+      $phar = new \PharData("$base.tar");
+      $phar->addFile("$base.sql");
+      $phar->compress(\Phar::GZ);
+      unlink("$base.tar");
+      // Remove the loose .sql so the import's ArchiveUnpack (no overwrite flag)
+      // extracts cleanly — mirrors what a real pull leaves on disk.
+      unlink("$base.sql");
+
       $snapshotRefresh = $this->taskSnapshotRefresh($opts);
       $mockBuilder = $this->mockCollectionBuilder();
 
       $snapshotViaBackup = $this->taskSnapshotViaBackup($opts);
+      $snapshotImport = $this->taskSnapshotImport([...$opts, 'gzip' => true]);
       $dbSanitize = $this->taskDbSanitize($opts);
+      $snapshotReexport = $this->taskSnapshotCreate([...$opts, 'ispantheon' => false]);
       $snapshotPut = $this->taskSnapshotPut($opts);
 
       // Stage 1: Pantheon backup path — note the GENERIC site 'acme-widgets'.
@@ -90,20 +115,47 @@ namespace PL\Tests\Robo\Task\Testor {
       $mockBuilder->shouldReceive('taskSnapshotViaBackup')
         ->once()
         ->andReturn($snapshotViaBackup);
+      $mockBuilder->shouldReceive('taskSnapshotImport')
+        ->once()
+        ->andReturn($snapshotImport);
       $mockBuilder->shouldReceive('taskDbSanitize')
         ->once()
         ->andReturn($dbSanitize);
+      $mockBuilder->shouldReceive('taskSnapshotCreate')
+        ->once()
+        ->andReturn($snapshotReexport);
       $mockBuilder->shouldReceive('taskSnapshotPut')
         ->once()
         ->andReturn($snapshotPut);
 
-      // Stage 2: the GENERIC sanitize command from the fixture.
+      // Stage 2: import — unpack (real Phar) then the GENERIC sql.command.
+      $mockBuilder->shouldReceive('taskArchiveUnpack')
+        ->once()
+        ->andReturnUsing(fn(...$args) => $this->taskArchiveUnpack(...$args));
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('$(drush sql:connect) < __generic_refresh.sql')
+        ->andReturn($this->mockTaskExec($snapshotImport, 0, 'imported'));
+
+      // Stage 3: the GENERIC sanitize command from the fixture.
       $mockBuilder->shouldReceive('taskExec')
         ->once()
         ->with('drush sql:sanitize --sanitize-email=redacted@example.test')
         ->andReturn($this->mockTaskExec($dbSanitize, 0, 'OK'));
 
-      // Stage 3: put into the GENERIC bucket 'nightly-dumps'.
+      // Stage 4: re-export — the GENERIC sqldump.command then pack.
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('drush sql:dump > __generic_refresh.sql')
+        ->andReturnUsing(function () use ($snapshotReexport) {
+          file_put_contents('__generic_refresh.sql', 'sanitized dump');
+          return $this->mockTaskExec($snapshotReexport, 0, 'dumped');
+        });
+      $mockBuilder->shouldReceive('taskArchivePack')
+        ->once()
+        ->andReturnUsing(fn(...$args) => $this->taskArchivePack(...$args));
+
+      // Stage 5: put into the GENERIC bucket 'nightly-dumps'.
       $this->mockS3Client->shouldReceive('putObject')
         ->once()
         ->with([
@@ -114,7 +166,9 @@ namespace PL\Tests\Robo\Task\Testor {
         ->andReturn(new \Aws\Result());
 
       $snapshotViaBackup->setBuilder($mockBuilder);
+      $snapshotImport->setBuilder($mockBuilder);
       $dbSanitize->setBuilder($mockBuilder);
+      $snapshotReexport->setBuilder($mockBuilder);
       $snapshotPut->setBuilder($mockBuilder);
       $snapshotRefresh->setBuilder($mockBuilder);
 

--- a/tests/Robo/Task/Testor/SnapshotRefreshTest.php
+++ b/tests/Robo/Task/Testor/SnapshotRefreshTest.php
@@ -6,11 +6,22 @@ namespace PL\Tests\Robo\Task\Testor {
 
   /**
    * Tests for {@see SnapshotRefresh}, the generic producer orchestration
-   * (issue #27): (optionally) pull → sanitize → put, driven entirely by config.
+   * (issue #27, hardened for the security fix in issue #33).
+   *
+   * The SECURITY-CRITICAL chain is:
+   *
+   *   (optional) pull -> IMPORT -> sanitize -> RE-EXPORT -> put
+   *
+   * The import and re-export are what make the sanitize operate on — and the
+   * push carry — the *pulled* production data. Without them the sanitize would
+   * mutate some unrelated already-connected local DB while the raw prod
+   * download was pushed untouched (issue #33: real staff PII + password hashes
+   * leaked to shared storage).
    *
    * The chain is exercised with faked collaborators (a mocked collection
-   * builder returning real sub-tasks whose taskExec / S3 client are mocked),
-   * the same way {@see SnapshotGetTest} fakes SnapshotList.
+   * builder returning real sub-tasks whose taskExec / S3 client / Phar files are
+   * real or mocked), the same way {@see SnapshotGetTest} fakes SnapshotList and
+   * the pre-#33 version of this test did.
    *
    * Genericness is proven by {@see SnapshotRefreshGenericConfigTest}, which runs
    * the same chain against a second, deliberately non-performantlabs.com config
@@ -21,19 +32,101 @@ namespace PL\Tests\Robo\Task\Testor {
 
     public function tearDown(): void {
       parent::tearDown();
-      foreach (['__test_refresh.sql', '__test_refresh.tar', '__test_refresh.tar.gz'] as $f) {
+      foreach ([
+        '__test_refresh.sql',
+        '__test_refresh.tar',
+        '__test_refresh.tar.gz',
+      ] as $f) {
         if (file_exists($f)) {
-          unlink($f);
+          // For .tar.gz, evict the per-process Phar registration WHILE the file
+          // still exists (Phar::unlinkArchive needs a readable file); a bare
+          // unlink() strands the registration and makes the next test's pack in
+          // this same PHPUnit process collide.
+          if (str_ends_with($f, '.tar.gz')) {
+            \Phar::unlinkArchive($f);
+          }
+          else {
+            unlink($f);
+          }
         }
       }
     }
 
     /**
-     * Full pull path against a local (@self) env: SnapshotCreate (drush
-     * sql:dump + archive) → DbSanitize → SnapshotPut. All three stages run and
-     * the chain succeeds.
+     * Build a real `__test_refresh.tar.gz` (containing a one-line `.sql`) so
+     * the import stage's ArchiveUnpack has a real archive to extract. Mirrors
+     * what a pull stage would have produced on disk.
      */
-    public function testFullPullLocalRunsCreateSanitizePut() {
+    private function seedArchive(string $base, string $sql): void {
+      file_put_contents("$base.sql", $sql);
+      $phar = new \PharData("$base.tar");
+      $phar->addFile("$base.sql");
+      $phar->compress(\Phar::GZ);
+      unlink("$base.tar");
+      // Remove the loose .sql so it mirrors what a real pull leaves on disk
+      // (ArchivePack->rmOrig() deletes it). ArchiveUnpack extracts WITHOUT an
+      // overwrite flag, so a pre-existing .sql would make the import's unpack
+      // fail with "path already exists" instead of exercising the real path.
+      unlink("$base.sql");
+    }
+
+    /**
+     * Register the mock-builder expectations for the IMPORT + RE-EXPORT stages
+     * that are common to every full-chain test. Returns the two real sub-tasks
+     * so the caller can attach the builder to them.
+     *
+     * IMPORT   : ArchiveUnpack("$base.tar.gz") then `sql.command < $base.sql`.
+     * RE-EXPORT: `sqldump.command > $base.sql` then ArchivePack -> "$base.tar.gz".
+     *
+     * @return array{0: \PL\Robo\Task\Testor\SnapshotImport, 1: \PL\Robo\Task\Testor\SnapshotCreate}
+     */
+    private function expectImportAndReexport($mockBuilder, array $opts, string $base) {
+      $snapshotImport = $this->taskSnapshotImport([...$opts, 'gzip' => true]);
+      $snapshotReexport = $this->taskSnapshotCreate([...$opts, 'ispantheon' => false]);
+
+      // The refresh chain constructs the import + re-export sub-tasks.
+      $mockBuilder->shouldReceive('taskSnapshotImport')
+        ->once()
+        ->andReturn($snapshotImport);
+      $mockBuilder->shouldReceive('taskSnapshotCreate')
+        ->once()
+        ->andReturn($snapshotReexport);
+
+      // IMPORT: unpack is a real Phar op (no taskExec); then the load command.
+      $mockBuilder->shouldReceive('taskArchiveUnpack')
+        ->once()
+        ->andReturnUsing(fn(...$args) => $this->taskArchiveUnpack(...$args));
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('$(drush sql:connect) < ' . "$base.sql")
+        ->andReturn($this->mockTaskExec($snapshotImport, 0, 'imported'));
+
+      // RE-EXPORT: dump the (now-sanitized) DB, then pack it.
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('drush sql:dump > ' . "$base.sql")
+        ->andReturnUsing(function () use ($snapshotReexport, $base) {
+          // Emulate the dump writing a fresh (sanitized) .sql to disk so the
+          // subsequent real ArchivePack has input.
+          file_put_contents("$base.sql", 'sanitized dump');
+          return $this->mockTaskExec($snapshotReexport, 0, 'dumped');
+        });
+      $mockBuilder->shouldReceive('taskArchivePack')
+        ->once()
+        ->andReturnUsing(fn(...$args) => $this->taskArchivePack(...$args));
+
+      $snapshotImport->setBuilder($mockBuilder);
+      $snapshotReexport->setBuilder($mockBuilder);
+
+      return [$snapshotImport, $snapshotReexport];
+    }
+
+    /**
+     * Full pull path against a local (@self) env: SnapshotCreate (drush
+     * sql:dump + archive) -> IMPORT -> DbSanitize -> RE-EXPORT -> SnapshotPut.
+     * All five stages run and the chain succeeds.
+     */
+    public function testFullPullLocalRunsCreateImportSanitizeReexportPut() {
       /** @var \Consolidation\Config\Config $testorConfig */
       $testorConfig = $this->getContainer()->get('testorConfig');
       $testorConfig->set('sanitize.command', 'drush sql:sanitize');
@@ -50,40 +143,64 @@ namespace PL\Tests\Robo\Task\Testor {
       $snapshotRefresh = $this->taskSnapshotRefresh($opts);
       $mockBuilder = $this->mockCollectionBuilder();
 
-      // Sub-tasks the refresh chain will drive.
-      $snapshotCreate = $this->taskSnapshotCreate([...$opts, 'ispantheon' => false]);
-      $dbSanitize = $this->taskDbSanitize($opts);
-      $snapshotPut = $this->taskSnapshotPut($opts);
+      // The local path exercises SnapshotCreate + ArchivePack TWICE in one run:
+      // once for the pull (drush sql:dump -> pack) and once for the re-export
+      // (dump the sanitized DB -> pack). Register those two primitives with a
+      // shared expectation each so the double use is unambiguous.
+      $snapshotCreatePull = $this->taskSnapshotCreate([...$opts, 'ispantheon' => false]);
+      $snapshotReexport = $this->taskSnapshotCreate([...$opts, 'ispantheon' => false]);
+      $snapshotCreatePull->setBuilder($mockBuilder);
+      $snapshotReexport->setBuilder($mockBuilder);
+      $mockBuilder->shouldReceive('taskSnapshotCreate')
+        ->twice()
+        ->andReturn($snapshotCreatePull, $snapshotReexport);
 
-      // Stage 1: local dump (drush sql:dump) — SnapshotCreate uses taskExec then
-      // taskArchivePack. We create a real dump file so ArchivePack has input.
-      file_put_contents('__test_refresh.sql', 'select 1+1;');
+      // Both dumps issue the identical `drush sql:dump > …sql`; each writes a
+      // fresh .sql so the following real ArchivePack has input. (The pull dump
+      // carries a sentinel prod email; the re-export dump is the sanitized one.)
       $mockBuilder->shouldReceive('taskExec')
-        ->once()
+        ->twice()
         ->with('drush sql:dump > __test_refresh.sql')
-        ->andReturn($this->mockTaskExec($snapshotCreate, 0, 'OK'));
+        ->andReturnUsing(function () use ($snapshotCreatePull) {
+          file_put_contents('__test_refresh.sql', 'dump: aangel@performantlabs.com');
+          return $this->mockTaskExec($snapshotCreatePull, 0, 'OK');
+        });
+      // Two packs: pull-pack and re-export-pack, both real (they exercise the
+      // Phar::unlinkArchive eviction the fix added to ArchivePack).
       $mockBuilder->shouldReceive('taskArchivePack')
-        ->once()
+        ->twice()
         ->andReturnUsing(fn(...$args) => $this->taskArchivePack(...$args));
 
-      // The refresh task itself drives sub-tasks via the mocked builder.
-      $mockBuilder->shouldReceive('taskSnapshotCreate')
+      // IMPORT stage (unpack the pull's archive, then load it).
+      $snapshotImport = $this->taskSnapshotImport([...$opts, 'gzip' => true]);
+      $snapshotImport->setBuilder($mockBuilder);
+      $mockBuilder->shouldReceive('taskSnapshotImport')
         ->once()
-        ->andReturn($snapshotCreate);
+        ->andReturn($snapshotImport);
+      $mockBuilder->shouldReceive('taskArchiveUnpack')
+        ->once()
+        ->andReturnUsing(fn(...$args) => $this->taskArchiveUnpack(...$args));
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('$(drush sql:connect) < __test_refresh.sql')
+        ->andReturn($this->mockTaskExec($snapshotImport, 0, 'imported'));
+
+      // Stage 3: sanitize.
+      $dbSanitize = $this->taskDbSanitize($opts);
       $mockBuilder->shouldReceive('taskDbSanitize')
         ->once()
         ->andReturn($dbSanitize);
-      $mockBuilder->shouldReceive('taskSnapshotPut')
-        ->once()
-        ->andReturn($snapshotPut);
-
-      // Stage 2: sanitize.
       $mockBuilder->shouldReceive('taskExec')
         ->once()
         ->with('drush sql:sanitize')
         ->andReturn($this->mockTaskExec($dbSanitize, 0, 'OK'));
+      $dbSanitize->setBuilder($mockBuilder);
 
-      // Stage 3: put — SnapshotPut uses the S3 client directly.
+      // Stage 5: put.
+      $snapshotPut = $this->taskSnapshotPut($opts);
+      $mockBuilder->shouldReceive('taskSnapshotPut')
+        ->once()
+        ->andReturn($snapshotPut);
       $this->mockS3Client->shouldReceive('putObject')
         ->once()
         ->with([
@@ -92,10 +209,8 @@ namespace PL\Tests\Robo\Task\Testor {
           'SourceFile' => '__test_refresh.tar.gz',
         ])
         ->andReturn(new \Aws\Result());
-
-      $snapshotCreate->setBuilder($mockBuilder);
-      $dbSanitize->setBuilder($mockBuilder);
       $snapshotPut->setBuilder($mockBuilder);
+
       $snapshotRefresh->setBuilder($mockBuilder);
 
       $result = $snapshotRefresh->run();
@@ -103,12 +218,13 @@ namespace PL\Tests\Robo\Task\Testor {
     }
 
     /**
-     * Full pull path against a Pantheon env: the backup-based path
-     * (SnapshotViaBackup: terminus backup:create/list/get) is used instead of a
-     * local dump, then sanitize → put. Proves the env branch selects the
-     * Pantheon puller.
+     * Full pull path against a Pantheon env: SnapshotViaBackup (terminus
+     * backup:create/list/get, landing a raw .tar.gz) -> IMPORT -> DbSanitize ->
+     * RE-EXPORT -> SnapshotPut. Proves the env branch selects the Pantheon
+     * puller AND that the raw download is imported/sanitized/re-exported before
+     * the push — the exact leak in issue #33.
      */
-    public function testFullPullPantheonUsesViaBackup() {
+    public function testFullPullPantheonImportsSanitizesReexportsBeforePut() {
       /** @var \Consolidation\Config\Config $testorConfig */
       $testorConfig = $this->getContainer()->get('testorConfig');
       $testorConfig->set('sanitize.command', 'drush sql:sanitize');
@@ -128,14 +244,19 @@ namespace PL\Tests\Robo\Task\Testor {
         'filename' => '__test_refresh',
       ];
 
+      // Seed the raw download the Pantheon puller would have produced, so the
+      // import stage has a real archive to unpack. Contains a sentinel prod
+      // email — the analogue of the real leak.
+      $this->seedArchive('__test_refresh', 'raw prod dump: aangel@performantlabs.com');
+
       $snapshotRefresh = $this->taskSnapshotRefresh($opts);
       $mockBuilder = $this->mockCollectionBuilder();
 
-      $snapshotViaBackup = $this->taskSnapshotViaBackup($opts);
-      $dbSanitize = $this->taskDbSanitize($opts);
-      $snapshotPut = $this->taskSnapshotPut($opts);
-
       // Stage 1: Pantheon backup path — three terminus commands.
+      $snapshotViaBackup = $this->taskSnapshotViaBackup($opts);
+      $mockBuilder->shouldReceive('taskSnapshotViaBackup')
+        ->once()
+        ->andReturn($snapshotViaBackup);
       $mockBuilder->shouldReceive('taskExec')
         ->once()
         ->with('terminus backup:create performant-labs.dev --element=database --keep-for=1')
@@ -148,86 +269,27 @@ namespace PL\Tests\Robo\Task\Testor {
         ->once()
         ->with('terminus backup:get performant-labs.dev --file=performant-labs_11111_database.sql.gz --to=__test_refresh.tar.gz')
         ->andReturn($this->mockTaskExec($snapshotViaBackup, 0, 'OK'));
-
-      $mockBuilder->shouldReceive('taskSnapshotViaBackup')
-        ->once()
-        ->andReturn($snapshotViaBackup);
-      $mockBuilder->shouldReceive('taskDbSanitize')
-        ->once()
-        ->andReturn($dbSanitize);
-      $mockBuilder->shouldReceive('taskSnapshotPut')
-        ->once()
-        ->andReturn($snapshotPut);
-
-      // Stage 2: sanitize.
-      $mockBuilder->shouldReceive('taskExec')
-        ->once()
-        ->with('drush sql:sanitize')
-        ->andReturn($this->mockTaskExec($dbSanitize, 0, 'OK'));
-
-      // Stage 3: put.
-      $this->mockS3Client->shouldReceive('putObject')
-        ->once()
-        ->with([
-          'Bucket' => 'snapshot',
-          'Key' => 'test/__test_refresh.tar.gz',
-          'SourceFile' => '__test_refresh.tar.gz',
-        ])
-        ->andReturn(new \Aws\Result());
-
       $snapshotViaBackup->setBuilder($mockBuilder);
-      $dbSanitize->setBuilder($mockBuilder);
-      $snapshotPut->setBuilder($mockBuilder);
-      $snapshotRefresh->setBuilder($mockBuilder);
 
-      $result = $snapshotRefresh->run();
-      self::assertEquals(0, $result->getExitCode());
-    }
+      // Stages 2 + 4: import and re-export.
+      $this->expectImportAndReexport($mockBuilder, $opts, '__test_refresh');
 
-    /**
-     * Skip-download path: with --skip-download, the pull stage must NOT run at
-     * all (no terminus, no drush sql:dump) — only sanitize → put run against the
-     * already-local dump.
-     *
-     * The decisive guarantee is that NO pull sub-task is invoked: neither
-     * taskSnapshotViaBackup nor taskSnapshotCreate is set up on the mock, so if
-     * the code tried to pull, Mockery would fail the test on the unexpected
-     * call.
-     */
-    public function testSkipDownloadRunsOnlySanitizeAndPut() {
-      /** @var \Consolidation\Config\Config $testorConfig */
-      $testorConfig = $this->getContainer()->get('testorConfig');
-      $testorConfig->set('sanitize.command', 'drush sql:sanitize');
-
-      $opts = [
-        'env' => '@self',
-        'name' => 'test',
-        'element' => 'database',
-        'do-not-sanitize' => false,
-        'skip-download' => true,
-        'filename' => '__test_refresh',
-      ];
-
-      $snapshotRefresh = $this->taskSnapshotRefresh($opts);
-      $mockBuilder = $this->mockCollectionBuilder();
-
+      // Stage 3: sanitize.
       $dbSanitize = $this->taskDbSanitize($opts);
-      $snapshotPut = $this->taskSnapshotPut($opts);
-
-      // NO taskSnapshotViaBackup / taskSnapshotCreate expectations: any pull
-      // attempt is an unexpected call and fails the test.
       $mockBuilder->shouldReceive('taskDbSanitize')
         ->once()
         ->andReturn($dbSanitize);
-      $mockBuilder->shouldReceive('taskSnapshotPut')
-        ->once()
-        ->andReturn($snapshotPut);
-
       $mockBuilder->shouldReceive('taskExec')
         ->once()
         ->with('drush sql:sanitize')
         ->andReturn($this->mockTaskExec($dbSanitize, 0, 'OK'));
+      $dbSanitize->setBuilder($mockBuilder);
 
+      // Stage 5: put.
+      $snapshotPut = $this->taskSnapshotPut($opts);
+      $mockBuilder->shouldReceive('taskSnapshotPut')
+        ->once()
+        ->andReturn($snapshotPut);
       $this->mockS3Client->shouldReceive('putObject')
         ->once()
         ->with([
@@ -236,9 +298,8 @@ namespace PL\Tests\Robo\Task\Testor {
           'SourceFile' => '__test_refresh.tar.gz',
         ])
         ->andReturn(new \Aws\Result());
-
-      $dbSanitize->setBuilder($mockBuilder);
       $snapshotPut->setBuilder($mockBuilder);
+
       $snapshotRefresh->setBuilder($mockBuilder);
 
       $result = $snapshotRefresh->run();
@@ -246,19 +307,16 @@ namespace PL\Tests\Robo\Task\Testor {
     }
 
     /**
-     * Short-circuit: if SANITIZE fails, PUT must NEVER run — pushing an
-     * unsanitized dump to storage is the exact failure this guards against.
+     * Skip-download path: with --skip-download the pull stage must NOT run at
+     * all (no terminus, no drush sql:dump), but the SECURITY stages still do —
+     * the already-local dump is imported, sanitized, and re-exported before
+     * being pushed. (Re-pushing a stale raw dump untouched would re-leak.)
      *
-     * The decisive guarantee: taskSnapshotPut is asserted `never()`, and the S3
-     * client's putObject has no expectation, so any push after a failed
-     * sanitize fails the test.
-     *
-     * Mutation evidence (documented in the PR): removing the
-     * `if (!$result->wasSuccessful()) return $result;` guard after the sanitize
-     * stage in SnapshotRefresh::run() makes this test go RED (taskSnapshotPut is
-     * then invoked); restoring it makes it GREEN.
+     * The decisive guarantee that no pull runs: neither taskSnapshotViaBackup
+     * nor a *pull* taskSnapshotCreate is set up as more than the single
+     * re-export SnapshotCreate — so an extra pull would be an unexpected call.
      */
-    public function testSanitizeFailureShortCircuitsPut() {
+    public function testSkipDownloadStillImportsSanitizesReexportsPut() {
       /** @var \Consolidation\Config\Config $testorConfig */
       $testorConfig = $this->getContainer()->get('testorConfig');
       $testorConfig->set('sanitize.command', 'drush sql:sanitize');
@@ -272,27 +330,233 @@ namespace PL\Tests\Robo\Task\Testor {
         'filename' => '__test_refresh',
       ];
 
+      // Already-local raw dump to operate on.
+      $this->seedArchive('__test_refresh', 'stale raw dump: info@performantlabs.com');
+
       $snapshotRefresh = $this->taskSnapshotRefresh($opts);
       $mockBuilder = $this->mockCollectionBuilder();
 
-      $dbSanitize = $this->taskDbSanitize($opts);
+      // NO taskSnapshotViaBackup expectation: any Pantheon pull is unexpected.
+      $mockBuilder->shouldReceive('taskSnapshotViaBackup')->never();
 
+      // Stages 2 + 4: import and re-export. NOTE taskSnapshotCreate is expected
+      // exactly ONCE here (the re-export) — a second call (an erroneous pull)
+      // would exceed the ->once() and fail the test.
+      $this->expectImportAndReexport($mockBuilder, $opts, '__test_refresh');
+
+      // Stage 3: sanitize.
+      $dbSanitize = $this->taskDbSanitize($opts);
       $mockBuilder->shouldReceive('taskDbSanitize')
         ->once()
         ->andReturn($dbSanitize);
-      // Put must never be constructed nor run.
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('drush sql:sanitize')
+        ->andReturn($this->mockTaskExec($dbSanitize, 0, 'OK'));
+      $dbSanitize->setBuilder($mockBuilder);
+
+      // Stage 5: put.
+      $snapshotPut = $this->taskSnapshotPut($opts);
       $mockBuilder->shouldReceive('taskSnapshotPut')
-        ->never();
+        ->once()
+        ->andReturn($snapshotPut);
+      $this->mockS3Client->shouldReceive('putObject')
+        ->once()
+        ->with([
+          'Bucket' => 'snapshot',
+          'Key' => 'test/__test_refresh.tar.gz',
+          'SourceFile' => '__test_refresh.tar.gz',
+        ])
+        ->andReturn(new \Aws\Result());
+      $snapshotPut->setBuilder($mockBuilder);
+
+      $snapshotRefresh->setBuilder($mockBuilder);
+
+      $result = $snapshotRefresh->run();
+      self::assertEquals(0, $result->getExitCode());
+    }
+
+    /**
+     * MUTATION GUARD — the NEW import short-circuit (issue #33).
+     *
+     * If the IMPORT stage fails, nothing after it may run — most importantly no
+     * re-export and no put. A failed import means the DB never received the
+     * pulled data, so sanitizing + pushing would either push a raw dump or a
+     * corrupted one. Mirrors testSanitizeFailureShortCircuitsPut.
+     *
+     * Mutation evidence (recorded in the PR): deleting the
+     * `if (!$result->wasSuccessful()) return $result;` guard after the import
+     * stage makes taskDbSanitize / taskSnapshotCreate(re-export) / taskSnapshotPut
+     * run and this test goes RED; restoring the guard makes it GREEN.
+     */
+    public function testImportFailureShortCircuitsRest() {
+      /** @var \Consolidation\Config\Config $testorConfig */
+      $testorConfig = $this->getContainer()->get('testorConfig');
+      $testorConfig->set('sanitize.command', 'drush sql:sanitize');
+
+      $opts = [
+        'env' => '@self',
+        'name' => 'test',
+        'element' => 'database',
+        'do-not-sanitize' => false,
+        'skip-download' => true,
+        'filename' => '__test_refresh',
+      ];
+
+      $this->seedArchive('__test_refresh', 'raw dump');
+
+      $snapshotRefresh = $this->taskSnapshotRefresh($opts);
+      $mockBuilder = $this->mockCollectionBuilder();
+
+      $snapshotImport = $this->taskSnapshotImport([...$opts, 'gzip' => true]);
+      $mockBuilder->shouldReceive('taskSnapshotImport')
+        ->once()
+        ->andReturn($snapshotImport);
+      // Unpack succeeds (real Phar), but the load command fails.
+      $mockBuilder->shouldReceive('taskArchiveUnpack')
+        ->once()
+        ->andReturnUsing(fn(...$args) => $this->taskArchiveUnpack(...$args));
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('$(drush sql:connect) < __test_refresh.sql')
+        ->andReturn($this->mockTaskExec(new \Robo\Result($snapshotImport, 1, 'IMPORT BLEW UP')));
+      $snapshotImport->setBuilder($mockBuilder);
+
+      // Nothing after import may run.
+      $mockBuilder->shouldReceive('taskDbSanitize')->never();
+      $mockBuilder->shouldReceive('taskSnapshotCreate')->never();
+      $mockBuilder->shouldReceive('taskSnapshotPut')->never();
+
+      $snapshotRefresh->setBuilder($mockBuilder);
+
+      $result = $snapshotRefresh->run();
+      self::assertEquals(1, $result->getExitCode());
+      self::assertStringContainsString('IMPORT BLEW UP', $result->getMessage());
+    }
+
+    /**
+     * MUTATION GUARD — the NEW re-export short-circuit (issue #33).
+     *
+     * If the RE-EXPORT stage fails, the put must NEVER run: the file on disk is
+     * then either the stale raw pre-sanitize dump or a partial/corrupted one,
+     * and pushing it would either re-leak prod PII or publish a broken snapshot.
+     *
+     * Mutation evidence (recorded in the PR): deleting the guard after the
+     * re-export stage makes taskSnapshotPut run and this test goes RED;
+     * restoring it makes it GREEN.
+     */
+    public function testReexportFailureShortCircuitsPut() {
+      /** @var \Consolidation\Config\Config $testorConfig */
+      $testorConfig = $this->getContainer()->get('testorConfig');
+      $testorConfig->set('sanitize.command', 'drush sql:sanitize');
+
+      $opts = [
+        'env' => '@self',
+        'name' => 'test',
+        'element' => 'database',
+        'do-not-sanitize' => false,
+        'skip-download' => true,
+        'filename' => '__test_refresh',
+      ];
+
+      $this->seedArchive('__test_refresh', 'raw dump');
+
+      $snapshotRefresh = $this->taskSnapshotRefresh($opts);
+      $mockBuilder = $this->mockCollectionBuilder();
+
+      // Import succeeds.
+      $snapshotImport = $this->taskSnapshotImport([...$opts, 'gzip' => true]);
+      $mockBuilder->shouldReceive('taskSnapshotImport')->once()->andReturn($snapshotImport);
+      $mockBuilder->shouldReceive('taskArchiveUnpack')
+        ->once()
+        ->andReturnUsing(fn(...$args) => $this->taskArchiveUnpack(...$args));
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('$(drush sql:connect) < __test_refresh.sql')
+        ->andReturn($this->mockTaskExec($snapshotImport, 0, 'imported'));
+      $snapshotImport->setBuilder($mockBuilder);
+
+      // Sanitize succeeds.
+      $dbSanitize = $this->taskDbSanitize($opts);
+      $mockBuilder->shouldReceive('taskDbSanitize')->once()->andReturn($dbSanitize);
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('drush sql:sanitize')
+        ->andReturn($this->mockTaskExec($dbSanitize, 0, 'OK'));
+      $dbSanitize->setBuilder($mockBuilder);
+
+      // Re-export FAILS on its dump command.
+      $snapshotReexport = $this->taskSnapshotCreate([...$opts, 'ispantheon' => false]);
+      $mockBuilder->shouldReceive('taskSnapshotCreate')->once()->andReturn($snapshotReexport);
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('drush sql:dump > __test_refresh.sql')
+        ->andReturn($this->mockTaskExec(new \Robo\Result($snapshotReexport, 1, 'REEXPORT BLEW UP')));
+      $snapshotReexport->setBuilder($mockBuilder);
+
+      // Put must never run.
+      $mockBuilder->shouldReceive('taskSnapshotPut')->never();
+
+      $snapshotRefresh->setBuilder($mockBuilder);
+
+      $result = $snapshotRefresh->run();
+      self::assertEquals(1, $result->getExitCode());
+      self::assertStringContainsString('REEXPORT BLEW UP', $result->getMessage());
+    }
+
+    /**
+     * Short-circuit: if SANITIZE fails, RE-EXPORT and PUT must NEVER run —
+     * pushing an unsanitized dump to storage is the exact failure this guards
+     * against.
+     *
+     * Mutation evidence (recorded in the PR): removing the guard after the
+     * sanitize stage makes taskSnapshotCreate(re-export)/taskSnapshotPut run and
+     * this test goes RED; restoring it makes it GREEN.
+     */
+    public function testSanitizeFailureShortCircuitsRest() {
+      /** @var \Consolidation\Config\Config $testorConfig */
+      $testorConfig = $this->getContainer()->get('testorConfig');
+      $testorConfig->set('sanitize.command', 'drush sql:sanitize');
+
+      $opts = [
+        'env' => '@self',
+        'name' => 'test',
+        'element' => 'database',
+        'do-not-sanitize' => false,
+        'skip-download' => true,
+        'filename' => '__test_refresh',
+      ];
+
+      $this->seedArchive('__test_refresh', 'raw dump');
+
+      $snapshotRefresh = $this->taskSnapshotRefresh($opts);
+      $mockBuilder = $this->mockCollectionBuilder();
+
+      // Import succeeds.
+      $snapshotImport = $this->taskSnapshotImport([...$opts, 'gzip' => true]);
+      $mockBuilder->shouldReceive('taskSnapshotImport')->once()->andReturn($snapshotImport);
+      $mockBuilder->shouldReceive('taskArchiveUnpack')
+        ->once()
+        ->andReturnUsing(fn(...$args) => $this->taskArchiveUnpack(...$args));
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('$(drush sql:connect) < __test_refresh.sql')
+        ->andReturn($this->mockTaskExec($snapshotImport, 0, 'imported'));
+      $snapshotImport->setBuilder($mockBuilder);
+
+      $dbSanitize = $this->taskDbSanitize($opts);
+      $mockBuilder->shouldReceive('taskDbSanitize')->once()->andReturn($dbSanitize);
+      // Re-export and put must never be constructed nor run.
+      $mockBuilder->shouldReceive('taskSnapshotCreate')->never();
+      $mockBuilder->shouldReceive('taskSnapshotPut')->never();
 
       // Sanitize fails.
       $mockBuilder->shouldReceive('taskExec')
         ->once()
         ->with('drush sql:sanitize')
         ->andReturn($this->mockTaskExec(new \Robo\Result($dbSanitize, 1, 'SANITIZE BLEW UP')));
-
-      // No putObject expectation: a push here is an unexpected call.
-
       $dbSanitize->setBuilder($mockBuilder);
+
       $snapshotRefresh->setBuilder($mockBuilder);
 
       $result = $snapshotRefresh->run();
@@ -301,7 +565,8 @@ namespace PL\Tests\Robo\Task\Testor {
     }
 
     /**
-     * Short-circuit: if the PULL stage fails, neither sanitize nor put runs.
+     * Short-circuit: if the PULL stage fails, none of import/sanitize/re-export/
+     * put runs.
      */
     public function testPullFailureShortCircuitsRest() {
       $opts = [
@@ -327,7 +592,8 @@ namespace PL\Tests\Robo\Task\Testor {
       $mockBuilder->shouldReceive('taskSnapshotCreate')
         ->once()
         ->andReturn($snapshotCreate);
-      // Neither sanitize nor put may run.
+      // Nothing downstream may run.
+      $mockBuilder->shouldReceive('taskSnapshotImport')->never();
       $mockBuilder->shouldReceive('taskDbSanitize')->never();
       $mockBuilder->shouldReceive('taskSnapshotPut')->never();
 


### PR DESCRIPTION
## Summary

`snapshot:refresh` chained **pull → sanitize → put**. `drush sql:sanitize` only ever mutates the database drush is *connected* to — it cannot reach into the pulled dump file on disk. So the sanitize ran against an unrelated already-local DB while `SnapshotPut` uploaded the **untouched raw production download**, leaking every real user email and password hash to shared storage while exiting 0 and reporting "User emails sanitized". Verified on a real `--env=live` run in the original report.

**Both pull paths were broken**, not just Pantheon. The issue text describes the local/`@self` path as safe, but within `SnapshotRefresh` the `@self` puller (`SnapshotCreate`) dumps the live DB in the pull stage *before* the sanitize stage runs, so the pushed `.sql` is likewise pre-sanitize. The Pantheon path is the primary intended path and the one caught live, but the underlying dump-before-sanitize flaw is identical, so both are fixed the same way. (The standalone `snapshot:create` command already dumps *after* sanitize and is unaffected.)

## Fix

Extend the chain to import the pulled dump into the DB, sanitize **that** DB in place, then re-export it before pushing:

```
pull → import → sanitize → re-export → put
```

- **Import** reuses the existing `SnapshotImport` task (`sql.command < file.sql`).
- **Re-export** reuses `SnapshotCreate`'s local branch (`sqldump.command > file.sql`, then pack).
- The chain **short-circuits** on a failed import or re-export, so no unsanitized or corrupted file can reach `SnapshotPut` — same guarantee the sanitize stage already had.

### Config: no new keys required

Both `sql.command` and `sqldump.command` already exist in `TestorConfig`'s placeholder and in the test fixtures. `sql.command` is legitimately shared with the consumer path (`snapshot:restore`): producer (staging a temp import for sanitization) and consumer (final restore into a preview's DB) are different use cases but the same "load SQL into the drush-connected DB" primitive, and they never run concurrently against the same DB. **No companion change to `Performant-Labs/performantlabs.com` is needed** — its `.testor.yml` already carries both keys (they are in the shipped placeholder).

### Secondary fix: ArchivePack Phar eviction

The hardened chain packs the same `.tar.gz` twice in one run (pull-pack, then re-export-pack). PHP's `Phar` keeps a per-process registry keyed by filename and refuses to overwrite a still-registered path, so `compress()` failed with *"a phar with that name already exists"*. This was a **real runtime bug the new chain would have hit** (caught by the tests, not just in test scaffolding). `ArchivePack::run()` now evicts any cached registration for the target path via `Phar::unlinkArchive()` before recreating it.

## Verification

**Real end-to-end sentinel proof against a live MariaDB** (throwaway container, synthetic data — nothing touched real credentials or the real bucket):

| Chain | Pushed artifact contains `aangel@performantlabs.com`? | Contains sanitized form `user+1@example.com`? |
|-------|:--:|:--:|
| OLD (pull→sanitize→put) | **YES — leak reproduced** | no |
| NEW (pull→import→sanitize→re-export→put) | **no** | **YES** |

**Mutation-tested short-circuits.** Three new/updated guard tests; removing each guard in `SnapshotRefresh::run()` turns its test RED, restoring it turns it GREEN:
- `testImportFailureShortCircuitsRest` — new import guard
- `testReexportFailureShortCircuitsPut` — new re-export guard
- `testSanitizeFailureShortCircuitsRest` — existing sanitize guard (unchanged behavior)

Full suite: **56 tests pass** (was 54; +2 short-circuit tests). `phpstan` clean at the repo's configured level.

## Label note

This repo has **no security-specific label** (only the default GitHub set). Applied `bug`; flagging here that this is a **security fix (PII / password-hash leak to shared storage)**, high severity, so it can be triaged accordingly.

Addresses #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)