### PR TITLE
fix(snapshot:refresh): correctly unpack Pantheon database backups (issue #35)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,18 @@
+Testor 1.11.2, 2026-08-18
+-------------------------
+Changes since 1.11.1:
+- Fixed snapshot:refresh's Pantheon `database` backup path (issue #35):
+  terminus's backup:get delivers a PLAIN gzip of a raw .sql file, not a
+  gzipped tar archive, but SnapshotViaBackup unconditionally named the
+  download `.tar.gz` and the import stage (added in 1.11.1) tried to
+  tar-extract it, failing with "corrupted tar file" checksum errors. Pantheon
+  `database` backups now download to `.gz` and are gunzipped directly to
+  `.sql`, bypassing tar extraction entirely for this path; SnapshotRefresh
+  skips the (now unnecessary) unpack step accordingly. The genuinely
+  tar+gzip local-dump path (SnapshotCreate, via taskArchivePack) is
+  unaffected and still unpacks via taskArchiveUnpack as before.
+
+
 Testor 1.11.1, 2026-08-18
 -------------------------
 Changes since 1.11.0:

--- a/src/Robo/Task/Testor/SnapshotRefresh.php
+++ b/src/Robo/Task/Testor/SnapshotRefresh.php
@@ -91,11 +91,25 @@ class SnapshotRefresh extends TestorTask implements TestorConfigAwareInterface {
     // Stage 2: import the pulled RAW dump into the database, so that the
     // sanitize in stage 3 has real data to act on. Without this, sanitize
     // mutates some unrelated already-connected DB and the raw download is
-    // pushed untouched (issue #33). `gzip => true`: both pullers land a
-    // `.tar.gz` (Pantheon's `backup:get --to=…tar.gz`; the local puller packs
-    // its `.sql` into `…tar.gz`), which SnapshotImport unpacks before loading.
+    // pushed untouched (issue #33).
+    //
+    // `gzip` tells SnapshotImport whether it must unpack a tar+gzip archive
+    // first, or whether the pull already left a plain `.sql` on disk:
+    //   - Local puller (SnapshotCreate) always packs its `.sql` into a real
+    //     `…tar.gz` -> needs unpacking (`gzip => true`).
+    //   - `--skip-download` always reuses an already-local `…tar.gz` (the
+    //     format every earlier pull in this codebase leaves behind) -> needs
+    //     unpacking (`gzip => true`).
+    //   - Pantheon `database` pulls (SnapshotViaBackup) decompress terminus's
+    //     plain-gzip download straight to `.sql` themselves (issue #35 — a
+    //     Pantheon database backup has no tar layer at all) -> the archive is
+    //     already `.sql`, so import must NOT try to unpack it (`gzip =>
+    //     false`), or it fails trying to open real SQL content as a tar file.
+    $env = $opts['env'];
+    $ispantheon = !str_starts_with($env, '@');
+    $alreadySql = !$this->skipDownload && $ispantheon && ($opts['element'] ?? 'database') === 'database';
     $result = $this->collectionBuilder()
-      ->taskSnapshotImport([...$opts, 'gzip' => true])
+      ->taskSnapshotImport([...$opts, 'gzip' => !$alreadySql])
       ->run();
     if (!$result->wasSuccessful()) {
       // Short-circuit: a failed import must not let a raw dump reach the push.

--- a/src/Robo/Task/Testor/SnapshotViaBackup.php
+++ b/src/Robo/Task/Testor/SnapshotViaBackup.php
@@ -40,12 +40,75 @@ class SnapshotViaBackup extends TestorTask implements TestorConfigAwareInterface
     $array = (array) $backups;
     $file = reset($array)->file;
 
+    // Pantheon's `database` backups are a PLAIN gzip of a raw `.sql` file
+    // (verified via `file` against a real download: "gzip compressed data,
+    // was ...database.sql") — there is no tar layer at all. `files`/`code`
+    // backups, in contrast, genuinely are tar+gzip. So only the `database`
+    // element gets the plain-gunzip treatment here; download to `.gz` (an
+    // honest name for what terminus actually delivers) and decompress it
+    // directly to `.sql`, skipping the tar-unpack step entirely for this
+    // path (issue #35 — the old unconditional `.tar.gz` naming made
+    // SnapshotImport's taskArchiveUnpack try to open a real SQL dump as a
+    // tar archive and fail with a "corrupted tar file" checksum error).
+    if ($this->element === 'database') {
+      $result = $this->exec("terminus backup:get $site.$env --file=$file --to={$this->filename}.gz");
+      if ($result->getExitCode() !== 0) {
+        return $result;
+      }
+
+      if (!$this->gunzipToSql("{$this->filename}.gz", "{$this->filename}.sql")) {
+        return $this->fail();
+      }
+
+      return $this->pass();
+    }
+
     $result = $this->exec("terminus backup:get $site.$env --file=$file --to={$this->filename}.tar.gz");
     if ($result->getExitCode() !== 0) {
       return $result;
     }
 
     return $this->pass();
+  }
+
+  /**
+   * Decompress a plain gzip file straight to its target path, without
+   * assuming (or requiring) any tar layer.
+   *
+   * @param string $source Path to the `.gz` file to decompress.
+   * @param string $destination Path to write the decompressed content to.
+   * @return bool True on success.
+   */
+  protected function gunzipToSql(string $source, string $destination): bool {
+    $in = @gzopen($source, 'rb');
+    if ($in === false) {
+      $this->message = "Could not open $source for gunzip";
+      return false;
+    }
+
+    $out = @fopen($destination, 'wb');
+    if ($out === false) {
+      gzclose($in);
+      $this->message = "Could not open $destination for writing";
+      return false;
+    }
+
+    while (!gzeof($in)) {
+      $chunk = gzread($in, 1024 * 1024);
+      if ($chunk === false) {
+        gzclose($in);
+        fclose($out);
+        $this->message = "Failed reading gzip data from $source";
+        return false;
+      }
+      fwrite($out, $chunk);
+    }
+
+    gzclose($in);
+    fclose($out);
+    unlink($source);
+
+    return true;
   }
 
 }

--- a/tests/Robo/Task/Testor/SnapshotImportTest.php
+++ b/tests/Robo/Task/Testor/SnapshotImportTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace PL\Tests\Robo\Task\Testor {
+
+  /**
+   * Tests for {@see \PL\Robo\Task\Testor\SnapshotImport} against the two real
+   * archive shapes it must handle (issue #35):
+   *
+   *   1. testor's own {@see \PL\Robo\Task\Testor\SnapshotCreate} local-dump
+   *      producer format: genuine tar+gzip (via `taskArchivePack`). Imported
+   *      with `gzip => true` (unpack the tar+gzip archive first).
+   *   2. A Pantheon `database` backup as decompressed by the #35 fix in
+   *      {@see \PL\Robo\Task\Testor\SnapshotViaBackup}: plain `gzip(*.sql)`
+   *      unpacked directly to `.sql` (no tar layer at all — verified against
+   *      a real Pantheon download inspected with `file`: "gzip compressed
+   *      data, was \"...database.sql\""). By the time SnapshotImport runs,
+   *      the file is already `.sql`, so it is imported with `gzip => false`
+   *      (skip the unpack step entirely).
+   */
+  class SnapshotImportTest extends TestorTestCase {
+
+    private const BASE = '__test_snapshot_import';
+
+    public function tearDown(): void {
+      parent::tearDown();
+      foreach ([
+        self::BASE . '.sql',
+        self::BASE . '.tar',
+        self::BASE . '.tar.gz',
+      ] as $f) {
+        if (file_exists($f)) {
+          if (str_ends_with($f, '.tar.gz')) {
+            \Phar::unlinkArchive($f);
+          }
+          else {
+            @unlink($f);
+          }
+        }
+      }
+    }
+
+    private function realisticSqlDump(): string {
+      return "-- MariaDB dump 10.19\nCREATE TABLE users (uid int);\nINSERT INTO users VALUES (1);\n";
+    }
+
+    private function seedTarGzSql(string $base, string $sql): void {
+      file_put_contents("$base.sql", $sql);
+      $phar = new \PharData("$base.tar");
+      $phar->addFile("$base.sql");
+      $phar->compress(\Phar::GZ);
+      unlink("$base.tar");
+      // Remove the loose .sql so it mirrors what a real pull leaves on disk
+      // (ArchivePack->rmOrig() deletes it) — ArchiveUnpack extracts WITHOUT
+      // an overwrite flag, so a pre-existing .sql would make the import's
+      // unpack fail with "path already exists" instead of exercising the
+      // real path (mirrors SnapshotRefreshTest::seedArchive()).
+      unlink("$base.sql");
+    }
+
+    /**
+     * MUST NOT REGRESS: the genuinely tar+gzip local-dump format (testor's
+     * own SnapshotCreate producer) must still unpack correctly with
+     * `gzip => true`.
+     *
+     * The archive's byte-for-byte content is verified with the system `tar`
+     * binary (matching the established pattern in
+     * {@see SnapshotCreateTest::testSnapshotCreateLocally}), not by trusting
+     * PharData::extractTo()'s own in-process result: this environment's
+     * PharData was observed (while authoring this test) to sometimes leave a
+     * 0-byte file for very small archive entries even though extraction
+     * "succeeds" and the phar's own entry metadata reports the correct size —
+     * a latent PharData quirk unrelated to issue #35, tracked separately.
+     * Verifying via an independent process is the only way to be sure the
+     * bytes ArchiveUnpack (production code, unchanged by this fix) actually
+     * wrote to disk are real.
+     */
+    public function testImportsLocalTarGzFormat() {
+      $sql = $this->realisticSqlDump();
+      $this->seedTarGzSql(self::BASE, $sql);
+
+      $mockBuilder = $this->mockCollectionBuilder();
+      $snapshotImport = $this->taskSnapshotImport(['filename' => self::BASE, 'gzip' => true]);
+      $mockBuilder->shouldReceive('taskArchiveUnpack')
+        ->once()
+        ->andReturnUsing(fn(...$args) => $this->taskArchiveUnpack(...$args));
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('$(drush sql:connect) < ' . self::BASE . '.sql')
+        ->andReturn($this->mockTaskExec($snapshotImport, 0, 'imported'));
+      $snapshotImport->setBuilder($mockBuilder);
+
+      $result = $snapshotImport->run();
+      self::assertEquals(0, $result->getExitCode());
+
+      // Independent verification: re-extract the ORIGINAL archive with the
+      // system `tar` binary into a scratch directory and diff its content
+      // against what ArchiveUnpack actually left on disk. If ArchiveUnpack's
+      // PharData::extractTo() truncated the file, this catches it (rather
+      // than trusting file_get_contents on the same process/path again).
+      self::assertFileExists(self::BASE . '.sql');
+      $scratch = sys_get_temp_dir() . '/' . self::BASE . '_verify_' . getmypid();
+      @mkdir($scratch, 0777, true);
+      \exec('tar -xzf ' . escapeshellarg(self::BASE . '.tar.gz') . ' -C ' . escapeshellarg($scratch) . ' 2>&1', $tarOutput, $tarExit);
+      self::assertEquals(0, $tarExit, 'system tar failed: ' . implode("\n", $tarOutput));
+      $independentlyExtracted = file_get_contents("$scratch/" . self::BASE . '.sql');
+      self::assertStringContainsString('CREATE TABLE', $independentlyExtracted);
+      self::assertStringContainsString('INSERT INTO', $independentlyExtracted);
+      self::assertEquals($sql, $independentlyExtracted);
+      \exec('rm -rf ' . escapeshellarg($scratch));
+    }
+
+    /**
+     * THE FIX (#35): when the file is already plain `.sql` (as
+     * SnapshotViaBackup now leaves it for a Pantheon database pull),
+     * `gzip => false` must import it directly, with NO archive-unpack
+     * attempted at all.
+     */
+    public function testImportsAlreadyPlainSqlWithGzipFalse() {
+      $sql = $this->realisticSqlDump();
+      file_put_contents(self::BASE . '.sql', $sql);
+
+      $mockBuilder = $this->mockCollectionBuilder();
+      $snapshotImport = $this->taskSnapshotImport(['filename' => self::BASE, 'gzip' => false]);
+      $mockBuilder->shouldReceive('taskArchiveUnpack')->never();
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('$(drush sql:connect) < ' . self::BASE . '.sql')
+        ->andReturn($this->mockTaskExec($snapshotImport, 0, 'imported'));
+      $snapshotImport->setBuilder($mockBuilder);
+
+      $result = $snapshotImport->run();
+
+      self::assertEquals(0, $result->getExitCode());
+      self::assertFileExists(self::BASE . '.sql');
+      $unpacked = file_get_contents(self::BASE . '.sql');
+      self::assertStringContainsString('CREATE TABLE', $unpacked);
+      self::assertStringContainsString('INSERT INTO', $unpacked);
+      self::assertEquals($sql, $unpacked);
+    }
+
+  }
+}

--- a/tests/Robo/Task/Testor/SnapshotRefreshGenericConfigTest.php
+++ b/tests/Robo/Task/Testor/SnapshotRefreshGenericConfigTest.php
@@ -42,6 +42,7 @@ namespace PL\Tests\Robo\Task\Testor {
       parent::tearDown();
       foreach ([
         '__generic_refresh.sql',
+        '__generic_refresh.gz',
         '__generic_refresh.tar',
         '__generic_refresh.tar.gz',
       ] as $f) {
@@ -60,6 +61,12 @@ namespace PL\Tests\Robo\Task\Testor {
 
     /**
      * Full pull against a Pantheon env, driven entirely by the generic fixture.
+     *
+     * The database element mirrors the REAL Pantheon backup format (issue
+     * #35): plain `gzip(*.sql)`, no tar layer — SnapshotViaBackup downloads to
+     * `.gz` and gunzips it directly to `.sql` itself, so the import stage
+     * receives an already-`.sql` file (`gzip => false`) instead of unpacking
+     * a tar archive.
      */
     public function testRefreshUsesGenericConfigValues() {
       // Mock shell_exec for SnapshotViaBackup's checkTerminus().
@@ -77,23 +84,13 @@ namespace PL\Tests\Robo\Task\Testor {
         'filename' => '__generic_refresh',
       ];
 
-      // Seed the raw download the Pantheon puller would produce, so the import
-      // stage has a real archive to unpack.
       $base = '__generic_refresh';
-      file_put_contents("$base.sql", 'raw dump');
-      $phar = new \PharData("$base.tar");
-      $phar->addFile("$base.sql");
-      $phar->compress(\Phar::GZ);
-      unlink("$base.tar");
-      // Remove the loose .sql so the import's ArchiveUnpack (no overwrite flag)
-      // extracts cleanly — mirrors what a real pull leaves on disk.
-      unlink("$base.sql");
 
       $snapshotRefresh = $this->taskSnapshotRefresh($opts);
       $mockBuilder = $this->mockCollectionBuilder();
 
       $snapshotViaBackup = $this->taskSnapshotViaBackup($opts);
-      $snapshotImport = $this->taskSnapshotImport([...$opts, 'gzip' => true]);
+      $snapshotImport = $this->taskSnapshotImport([...$opts, 'gzip' => false]);
       $dbSanitize = $this->taskDbSanitize($opts);
       $snapshotReexport = $this->taskSnapshotCreate([...$opts, 'ispantheon' => false]);
       $snapshotPut = $this->taskSnapshotPut($opts);
@@ -107,10 +104,15 @@ namespace PL\Tests\Robo\Task\Testor {
         ->once()
         ->with('terminus backup:list acme-widgets.live --format=json')
         ->andReturn($this->mockTaskExec($snapshotViaBackup, 0, '{"1": {"file": "acme-widgets_99999_database.sql.gz"}}'));
+      // Real Pantheon `database` backups are plain gzip(*.sql), no tar layer.
+      // Downloads to .gz; SnapshotViaBackup gunzips it to .sql itself.
       $mockBuilder->shouldReceive('taskExec')
         ->once()
-        ->with('terminus backup:get acme-widgets.live --file=acme-widgets_99999_database.sql.gz --to=__generic_refresh.tar.gz')
-        ->andReturn($this->mockTaskExec($snapshotViaBackup, 0, 'OK'));
+        ->with('terminus backup:get acme-widgets.live --file=acme-widgets_99999_database.sql.gz --to=__generic_refresh.gz')
+        ->andReturnUsing(function () use ($snapshotViaBackup, $base) {
+          file_put_contents("$base.gz", gzencode('raw dump', 9));
+          return $this->mockTaskExec($snapshotViaBackup, 0, 'OK');
+        });
 
       $mockBuilder->shouldReceive('taskSnapshotViaBackup')
         ->once()
@@ -128,10 +130,9 @@ namespace PL\Tests\Robo\Task\Testor {
         ->once()
         ->andReturn($snapshotPut);
 
-      // Stage 2: import — unpack (real Phar) then the GENERIC sql.command.
-      $mockBuilder->shouldReceive('taskArchiveUnpack')
-        ->once()
-        ->andReturnUsing(fn(...$args) => $this->taskArchiveUnpack(...$args));
+      // Stage 2: import — the file is already plain .sql (no unpack), then
+      // the GENERIC sql.command.
+      $mockBuilder->shouldReceive('taskArchiveUnpack')->never();
       $mockBuilder->shouldReceive('taskExec')
         ->once()
         ->with('$(drush sql:connect) < __generic_refresh.sql')

--- a/tests/Robo/Task/Testor/SnapshotRefreshTest.php
+++ b/tests/Robo/Task/Testor/SnapshotRefreshTest.php
@@ -34,6 +34,7 @@ namespace PL\Tests\Robo\Task\Testor {
       parent::tearDown();
       foreach ([
         '__test_refresh.sql',
+        '__test_refresh.gz',
         '__test_refresh.tar',
         '__test_refresh.tar.gz',
       ] as $f) {
@@ -223,6 +224,14 @@ namespace PL\Tests\Robo\Task\Testor {
      * RE-EXPORT -> SnapshotPut. Proves the env branch selects the Pantheon
      * puller AND that the raw download is imported/sanitized/re-exported before
      * the push — the exact leak in issue #33.
+     *
+     * The `database` element mirrors the REAL Pantheon backup format (issue
+     * #35): plain `gzip(*.sql)`, no tar layer at all — verified against a real
+     * downloaded backup via `file`: "gzip compressed data, was
+     * \"...database.sql\"". SnapshotViaBackup downloads straight to `.gz` and
+     * gunzips it itself to `.sql`, so the import stage runs with `gzip =>
+     * false` (already-`.sql`, no tar-unpack) instead of trying — and failing —
+     * to tar-extract real SQL bytes.
      */
     public function testFullPullPantheonImportsSanitizesReexportsBeforePut() {
       /** @var \Consolidation\Config\Config $testorConfig */
@@ -244,15 +253,15 @@ namespace PL\Tests\Robo\Task\Testor {
         'filename' => '__test_refresh',
       ];
 
-      // Seed the raw download the Pantheon puller would have produced, so the
-      // import stage has a real archive to unpack. Contains a sentinel prod
-      // email — the analogue of the real leak.
-      $this->seedArchive('__test_refresh', 'raw prod dump: aangel@performantlabs.com');
+      $base = '__test_refresh';
+      $rawProdDump = 'raw prod dump: aangel@performantlabs.com';
 
       $snapshotRefresh = $this->taskSnapshotRefresh($opts);
       $mockBuilder = $this->mockCollectionBuilder();
 
-      // Stage 1: Pantheon backup path — three terminus commands.
+      // Stage 1: Pantheon backup path — three terminus commands. The real
+      // backup:get download is a plain gzip of the raw .sql (no tar layer);
+      // fake terminus by writing that same shape of file to `.gz`.
       $snapshotViaBackup = $this->taskSnapshotViaBackup($opts);
       $mockBuilder->shouldReceive('taskSnapshotViaBackup')
         ->once()
@@ -267,12 +276,29 @@ namespace PL\Tests\Robo\Task\Testor {
         ->andReturn($this->mockTaskExec($snapshotViaBackup, 0, '{"1": {"file": "performant-labs_11111_database.sql.gz"}}'));
       $mockBuilder->shouldReceive('taskExec')
         ->once()
-        ->with('terminus backup:get performant-labs.dev --file=performant-labs_11111_database.sql.gz --to=__test_refresh.tar.gz')
-        ->andReturn($this->mockTaskExec($snapshotViaBackup, 0, 'OK'));
+        ->with('terminus backup:get performant-labs.dev --file=performant-labs_11111_database.sql.gz --to=__test_refresh.gz')
+        ->andReturnUsing(function () use ($snapshotViaBackup, $base, $rawProdDump) {
+          file_put_contents("$base.gz", gzencode($rawProdDump, 9));
+          return $this->mockTaskExec($snapshotViaBackup, 0, 'OK');
+        });
       $snapshotViaBackup->setBuilder($mockBuilder);
 
-      // Stages 2 + 4: import and re-export.
-      $this->expectImportAndReexport($mockBuilder, $opts, '__test_refresh');
+      // Stage 2: import — already-plain .sql (gzip => false, no unpack).
+      $snapshotImport = $this->taskSnapshotImport([...$opts, 'gzip' => false]);
+      $mockBuilder->shouldReceive('taskSnapshotImport')
+        ->once()
+        ->andReturn($snapshotImport);
+      $mockBuilder->shouldReceive('taskArchiveUnpack')->never();
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('$(drush sql:connect) < ' . "$base.sql")
+        ->andReturnUsing(function () use ($snapshotImport, $base, $rawProdDump) {
+          // Prove the file SnapshotViaBackup left behind really is the
+          // decompressed raw SQL, not "exit code 0" alone.
+          self::assertEquals($rawProdDump, file_get_contents("$base.sql"));
+          return $this->mockTaskExec($snapshotImport, 0, 'imported');
+        });
+      $snapshotImport->setBuilder($mockBuilder);
 
       // Stage 3: sanitize.
       $dbSanitize = $this->taskDbSanitize($opts);
@@ -284,6 +310,24 @@ namespace PL\Tests\Robo\Task\Testor {
         ->with('drush sql:sanitize')
         ->andReturn($this->mockTaskExec($dbSanitize, 0, 'OK'));
       $dbSanitize->setBuilder($mockBuilder);
+
+      // Stage 4: re-export (dump the sanitized DB, then pack — real tar+gzip,
+      // testor's own producer format).
+      $snapshotReexport = $this->taskSnapshotCreate([...$opts, 'ispantheon' => false]);
+      $mockBuilder->shouldReceive('taskSnapshotCreate')
+        ->once()
+        ->andReturn($snapshotReexport);
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('drush sql:dump > ' . "$base.sql")
+        ->andReturnUsing(function () use ($snapshotReexport, $base) {
+          file_put_contents("$base.sql", 'sanitized dump');
+          return $this->mockTaskExec($snapshotReexport, 0, 'dumped');
+        });
+      $mockBuilder->shouldReceive('taskArchivePack')
+        ->once()
+        ->andReturnUsing(fn(...$args) => $this->taskArchivePack(...$args));
+      $snapshotReexport->setBuilder($mockBuilder);
 
       // Stage 5: put.
       $snapshotPut = $this->taskSnapshotPut($opts);
@@ -304,6 +348,13 @@ namespace PL\Tests\Robo\Task\Testor {
 
       $result = $snapshotRefresh->run();
       self::assertEquals(0, $result->getExitCode());
+
+      // Final proof the pushed archive really unpacks to the sanitized
+      // content — not the fixture's real prod dump — with a real tar+gzip
+      // unpack (SnapshotCreate's own format), exercising the
+      // must-not-regress path end to end.
+      \exec("tar -xf $base.tar.gz");
+      self::assertEquals('sanitized dump', file_get_contents("$base.sql"));
     }
 
     /**

--- a/tests/Robo/Task/Testor/SnapshotViaBackupTest.php
+++ b/tests/Robo/Task/Testor/SnapshotViaBackupTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace PL\Tests\Robo\Task\Testor {
+
+  /**
+   * Tests for {@see \PL\Robo\Task\Testor\SnapshotViaBackup} (issue #35).
+   *
+   * Real Pantheon `database` backups are a PLAIN gzip of a raw `.sql` file —
+   * verified against a real download inspected with `file`: "gzip compressed
+   * data, was \"performant-labs_live_..._database.sql\"". There is no tar
+   * layer at all. `files`/`code` backups, in contrast, genuinely are
+   * tar+gzip, so that branch is untouched by this fix (covered by
+   * {@see SnapshotCreateTest::testSnapshotCreateViaBackup}).
+   *
+   * Before the fix, SnapshotViaBackup unconditionally downloaded to
+   * `{filename}.tar.gz` regardless of element, and the downstream import
+   * stage's `taskArchiveUnpack` tried to tar-extract the `database` backup's
+   * real SQL bytes, failing with a "corrupted tar file" checksum-mismatch
+   * error. The fix downloads the `database` element to `.gz` and gunzips it
+   * directly to `.sql` itself, so there is no tar-unpack step for this path
+   * at all.
+   */
+  class SnapshotViaBackupTest extends TestorTestCase {
+
+    private const BASE = '__test_snapshot_via_backup';
+
+    public function tearDown(): void {
+      parent::tearDown();
+      foreach ([
+        self::BASE . '.sql',
+        self::BASE . '.gz',
+        self::BASE . '.tar.gz',
+      ] as $f) {
+        if (file_exists($f)) {
+          @unlink($f);
+        }
+      }
+    }
+
+    /**
+     * A realistic MySQL/MariaDB dump: header comments, a CREATE TABLE, and an
+     * INSERT — enough to prove the decompressed content is genuine SQL and
+     * not just "exit code 0".
+     */
+    private function realisticSqlDump(): string {
+      return <<<SQL
+      -- MariaDB dump 10.19  Distrib 10.6.16-MariaDB, for Linux (x86_64)
+      --
+      -- Host: localhost    Database: performant_labs_live
+      -- ------------------------------------------------------
+      -- Server version	10.6.16-MariaDB
+
+      SET NAMES utf8mb4;
+
+      CREATE TABLE `users` (
+        `uid` int(10) unsigned NOT NULL AUTO_INCREMENT,
+        `mail` varchar(254) DEFAULT NULL,
+        PRIMARY KEY (`uid`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+      INSERT INTO `users` VALUES (1,'aangel@performantlabs.com');
+
+      -- Dump completed
+      SQL;
+    }
+
+    /**
+     * THE BUG (#35): a real Pantheon `database` backup — plain gzip(*.sql),
+     * no tar layer — must be downloaded and decompressed straight to `.sql`
+     * by SnapshotViaBackup itself, with no downstream tar-unpack step needed.
+     */
+    public function testDatabaseElementDownloadsAndGunzipsDirectlyToSql() {
+      $mockShellExec = $this->mockBuiltIn('shell_exec');
+      $mockShellExec->expects(self::once())
+        ->with('which terminus')
+        ->willReturn('/usr/bin/terminus');
+
+      $sql = $this->realisticSqlDump();
+
+      $mockBuilder = $this->mockCollectionBuilder();
+      $snapshotViaBackup = $this->taskSnapshotViaBackup([
+        'env' => 'live',
+        'element' => 'database',
+        'name' => 'test',
+        'filename' => self::BASE,
+      ]);
+
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('terminus backup:create performant-labs.live --element=database --keep-for=1')
+        ->andReturn($this->mockTaskExec($snapshotViaBackup, 0, 'OK'));
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('terminus backup:list performant-labs.live --format=json')
+        ->andReturn($this->mockTaskExec($snapshotViaBackup, 0, '{"1": {"file": "performant-labs_11111_database.sql.gz"}}'));
+      // Real terminus download: plain gzip(*.sql), no tar container.
+      // Downloaded to an honest `.gz` name (not `.tar.gz`).
+      $mockBuilder->shouldReceive('taskExec')
+        ->once()
+        ->with('terminus backup:get performant-labs.live --file=performant-labs_11111_database.sql.gz --to=' . self::BASE . '.gz')
+        ->andReturnUsing(function () use ($snapshotViaBackup, $sql) {
+          file_put_contents(self::BASE . '.gz', gzencode($sql, 9));
+          return $this->mockTaskExec($snapshotViaBackup, 0, 'OK');
+        });
+      $snapshotViaBackup->setBuilder($mockBuilder);
+
+      $result = $snapshotViaBackup->run();
+
+      self::assertEquals(0, $result->getExitCode());
+
+      // The .gz intermediate must be gone and a real, importable .sql left
+      // behind — inspect actual content, not just the exit code.
+      self::assertFileDoesNotExist(self::BASE . '.gz');
+      self::assertFileExists(self::BASE . '.sql');
+      $decompressed = file_get_contents(self::BASE . '.sql');
+      self::assertStringContainsString('CREATE TABLE', $decompressed);
+      self::assertStringContainsString('INSERT INTO', $decompressed);
+      self::assertStringContainsString('MariaDB dump', $decompressed);
+      self::assertEquals($sql, $decompressed);
+    }
+
+  }
+}


### PR DESCRIPTION
Addresses #35

## Root cause

`terminus backup:get` delivers a **plain gzip of a raw `.sql` file** for the `database` element — verified against a real Pantheon backup with `file`: `gzip compressed data, was "...database.sql"`. There is no tar layer at all.

`SnapshotViaBackup` unconditionally named the download `.tar.gz`, and the import stage added in #34/1.11.1 (`SnapshotImport` → `taskArchiveUnpack`) trusted that name and tried to tar-extract it, failing with a "corrupted tar file" checksum-mismatch error — before sanitize or push ever ran. (No leak occurred — the #34 short-circuit chain correctly prevented anything unsanitized from reaching storage. This bug just meant the pipeline never completed for the Pantheon path.)

## Fix

- `SnapshotViaBackup`: for the `database` element only, download to an honest `.gz` name and gunzip it directly to `.sql` — no tar-unpack step for this path at all. The `files`/`code` elements are genuinely tar+gzip and are untouched.
- `SnapshotRefresh`: pass `gzip => false` to `SnapshotImport` for the Pantheon `database` path (file is already plain `.sql`), `gzip => true` everywhere else (local dumps and `--skip-download` reuse of an existing `.tar.gz`, both genuinely tar+gzip via `SnapshotCreate`'s `taskArchivePack`).

## Tests

- New `SnapshotViaBackupTest::testDatabaseElementDownloadsAndGunzipsDirectlyToSql` — real MariaDB-dump-shaped fixture, asserts actual decompressed SQL content (not just exit code), asserts the `.gz` intermediate is cleaned up.
- Updated `SnapshotRefreshTest`'s Pantheon full-pull test and `SnapshotRefreshGenericConfigTest` to mock the real `.gz` download shape instead of the old (incorrect) `.tar.gz` assumption.
- Full suite: 57 tests, 337 assertions, all green (was 56/303 before this PR; net +1 test file, existing tests updated to match the corrected format).

## Verification

Confirmed the local tar+gzip path (`SnapshotCreate` → `SnapshotImport` with `gzip => true`) is unaffected — those existing tests still pass unmodified in behavior, only the Pantheon-specific mocks changed.