### PR TITLE
fix(archive): stop depending on PharData's broken Phar::GZ round-trip (issue #37)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,19 @@
+Testor 1.11.3, 2026-08-18
+-------------------------
+Changes since 1.11.2:
+- Fixed ArchivePack/ArchiveUnpack silently truncating content on extraction
+  (issue #37): PharData's own gzip round-trip (compress(Phar::GZ), then
+  re-open + extractTo()) writes a 0-byte file for the extracted entry on
+  both macOS and Linux PHP 8.3.x, despite reporting success and correct
+  archive metadata — a genuine PharData defect, not an environment quirk.
+  This affected snapshot:refresh's local/@self pull path and any
+  snapshot:get/snapshot:restore import against a locally-produced .tar.gz,
+  silently importing/restoring empty SQL while exiting 0. ArchivePack and
+  ArchiveUnpack now keep PharData for the tar layer only (confirmed
+  reliable) and gzip/gunzip via PHP's zlib streams directly, matching the
+  gunzipToSql pattern used by SnapshotViaBackup for issue #35.
+
+
 Testor 1.11.2, 2026-08-18
 -------------------------
 Changes since 1.11.1:

--- a/src/Robo/Task/Testor/ArchivePack.php
+++ b/src/Robo/Task/Testor/ArchivePack.php
@@ -28,22 +28,36 @@ class ArchivePack extends TestorTask {
       $archive = $this->archive;
 
       // Evict any Phar the current PHP process has already cached for the
-      // target "$archive.tar.gz" path. Phar keeps a per-process registry keyed
-      // by filename, and compress() refuses to overwrite a path that is still
-      // registered ("a phar with that name already exists"). This bites within
-      // a single `snapshot:refresh` run: the pull packs "$archive.tar.gz", the
-      // import unpacks it (registering that path), and the re-export then packs
-      // the SAME path again — which would fail without this eviction. Deleting
-      // the archive here is safe because we are about to recreate it.
-      if (file_exists("$archive.tar.gz")) {
-        \Phar::unlinkArchive("$archive.tar.gz");
+      // target "$archive.tar"/"$archive.tar.gz" paths. Phar keeps a
+      // per-process registry keyed by filename, and creating/converting a
+      // Phar refuses to overwrite a path that is still registered ("a phar
+      // with that name already exists"). This bites within a single
+      // `snapshot:refresh` run: the pull packs "$archive.tar.gz", the import
+      // unpacks it (registering "$archive.tar"), and the re-export then packs
+      // the SAME paths again — which would fail without this eviction.
+      // Deleting the archives here is safe because we are about to recreate
+      // them.
+      foreach (["$archive.tar", "$archive.tar.gz"] as $existing) {
+        if (file_exists($existing)) {
+          \Phar::unlinkArchive($existing);
+        }
       }
 
+      // Build the plain tar via PharData (reliable — see gzipFile()'s doc
+      // comment for why gzip is NOT done via PharData::compress(Phar::GZ),
+      // issue #37).
       $phar = new \PharData("$archive.tar");
       foreach ($this->files as $file) {
         $phar->addFile($file);
       }
-      $phar->compress(\Phar::GZ);
+      // Release the Phar handle before gzip-compressing the tar as a plain
+      // file, so nothing still has it open when it's read below.
+      unset($phar);
+
+      if (!$this->gzipFile("$archive.tar", "$archive.tar.gz")) {
+        return $this->fail();
+      }
+
       if ($this->rm_orig) foreach ($this->files as $file) {
         unlink($file);
       }

--- a/src/Robo/Task/Testor/ArchiveUnpack.php
+++ b/src/Robo/Task/Testor/ArchiveUnpack.php
@@ -15,8 +15,26 @@ class ArchiveUnpack extends TestorTask {
   public function run(): \Robo\Result {
     try {
       $filename = $this->archive;
-      $phar = new \PharData("$filename.tar.gz");
+
+      // Gunzip to a plain tar first, then extract via PharData — NOT
+      // `new \PharData("$filename.tar.gz")->extractTo()` directly.
+      // PharData's own gzip round-trip (compress/decompress-on-open) has
+      // been confirmed (issue #37) to silently write 0-byte extracted
+      // content on both macOS and Linux PHP 8.3.x, despite reporting success
+      // and correct archive metadata. Plain (uncompressed) PharData tar
+      // extraction is unaffected, so gzip is handled outside it entirely
+      // (see gzipFile()/gunzipFile() in TestorTask).
+      if (file_exists("$filename.tar")) {
+        \Phar::unlinkArchive("$filename.tar");
+      }
+      if (!$this->gunzipFile("$filename.tar.gz", "$filename.tar")) {
+        return $this->fail();
+      }
+
+      $phar = new \PharData("$filename.tar");
       $phar->extractTo($this->dir);
+      unset($phar);
+      unlink("$filename.tar");
     } catch (\Exception $exception) {
       $this->message = $exception->getMessage();
       return $this->fail();

--- a/src/Robo/Task/Testor/TestorTask.php
+++ b/src/Robo/Task/Testor/TestorTask.php
@@ -115,4 +115,87 @@ abstract class TestorTask extends \Robo\Task\BaseTask implements \Robo\Contract\
     return true;
   }
 
+  /**
+   * Gzip-compress a file to a new path via PHP's zlib streams, WITHOUT going
+   * through `PharData::compress(Phar::GZ)`. `PharData`'s own gzip round-trip
+   * (compress then re-open + extractTo) has been confirmed (issue #37) to
+   * silently write 0-byte extracted content on both macOS and Linux PHP
+   * 8.3.x, despite reporting success and correct archive metadata — plain
+   * (uncompressed) `PharData` tar handling is unaffected, so gzip is kept
+   * entirely outside it.
+   *
+   * @param string $source Path to the file to compress.
+   * @param string $destination Path to write the gzip-compressed file to.
+   * @return bool True on success (sets `$this->message` on failure).
+   */
+  protected function gzipFile(string $source, string $destination): bool {
+    $in = @fopen($source, 'rb');
+    if ($in === false) {
+      $this->message = "Could not open $source for gzip";
+      return false;
+    }
+
+    $out = @gzopen($destination, 'wb9');
+    if ($out === false) {
+      fclose($in);
+      $this->message = "Could not open $destination for writing";
+      return false;
+    }
+
+    while (!feof($in)) {
+      $chunk = fread($in, 1024 * 1024);
+      if ($chunk === false) {
+        fclose($in);
+        gzclose($out);
+        $this->message = "Failed reading data from $source";
+        return false;
+      }
+      gzwrite($out, $chunk);
+    }
+
+    fclose($in);
+    gzclose($out);
+
+    return true;
+  }
+
+  /**
+   * Gunzip a file to a new path via PHP's zlib streams, the mirror of
+   * {@see gzipFile} — see its doc comment for why this bypasses `PharData`.
+   *
+   * @param string $source Path to the `.gz` file to decompress.
+   * @param string $destination Path to write the decompressed content to.
+   * @return bool True on success (sets `$this->message` on failure).
+   */
+  protected function gunzipFile(string $source, string $destination): bool {
+    $in = @gzopen($source, 'rb');
+    if ($in === false) {
+      $this->message = "Could not open $source for gunzip";
+      return false;
+    }
+
+    $out = @fopen($destination, 'wb');
+    if ($out === false) {
+      gzclose($in);
+      $this->message = "Could not open $destination for writing";
+      return false;
+    }
+
+    while (!gzeof($in)) {
+      $chunk = gzread($in, 1024 * 1024);
+      if ($chunk === false) {
+        gzclose($in);
+        fclose($out);
+        $this->message = "Failed reading gzip data from $source";
+        return false;
+      }
+      fwrite($out, $chunk);
+    }
+
+    gzclose($in);
+    fclose($out);
+
+    return true;
+  }
+
 }

--- a/tests/Robo/Task/Testor/ArchivePackUnpackTest.php
+++ b/tests/Robo/Task/Testor/ArchivePackUnpackTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace PL\Tests\Robo\Task\Testor {
+
+  /**
+   * Tests for {@see \PL\Robo\Task\Testor\ArchivePack} and
+   * {@see \PL\Robo\Task\Testor\ArchiveUnpack} (issue #37).
+   *
+   * `PharData::compress(Phar::GZ)` followed by re-opening the resulting
+   * `.tar.gz` and calling `extractTo()` silently writes a 0-byte file for
+   * the extracted entry — `extractTo()` returns `true`, the archive's own
+   * entry metadata (via RecursiveIteratorIterator) correctly reports the
+   * original size, but the bytes on disk are gone. Confirmed reproducible
+   * on macOS PHP 8.3.31 (Homebrew) AND Linux PHP 8.3.33 (Debian bookworm,
+   * matching this repo's CI OS/PHP family) — not an environment quirk.
+   * Plain (uncompressed) PharData tar extraction is unaffected.
+   *
+   * This exercises the REAL (non-mocked) ArchivePack -> ArchiveUnpack
+   * round-trip end to end and asserts real byte-for-byte content, rather
+   * than trusting exit codes or archive metadata — the same discipline
+   * that caught #33.
+   */
+  class ArchivePackUnpackTest extends TestorTestCase {
+
+    private const BASE = '__test_archive_packunpack';
+
+    public function tearDown(): void {
+      parent::tearDown();
+      $targz = self::BASE . '.tar.gz';
+      if (file_exists($targz)) {
+        // Evict the per-process Phar registration before removing the file
+        // so a later test's archive at the same path doesn't collide.
+        \Phar::unlinkArchive($targz);
+      }
+      foreach ([self::BASE . '.sql', self::BASE . '.tar', $targz] as $f) {
+        if (file_exists($f)) {
+          unlink($f);
+        }
+      }
+    }
+
+    /**
+     * A realistic MySQL/MariaDB dump: header comments, a CREATE TABLE, and an
+     * INSERT — enough to prove the round-tripped content is genuine SQL and
+     * not just "exit code 0" / correct archive metadata.
+     */
+    private function realisticSqlDump(): string {
+      return <<<SQL
+      -- MariaDB dump 10.19  Distrib 10.6.16-MariaDB, for Linux (x86_64)
+      --
+      -- Host: localhost    Database: performant_labs_live
+      -- ------------------------------------------------------
+      -- Server version	10.6.16-MariaDB
+
+      SET NAMES utf8mb4;
+
+      CREATE TABLE `users` (
+        `uid` int(10) unsigned NOT NULL AUTO_INCREMENT,
+        `mail` varchar(254) DEFAULT NULL,
+        PRIMARY KEY (`uid`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+      INSERT INTO `users` VALUES (1,'aangel@performantlabs.com');
+
+      -- Dump completed
+      SQL;
+    }
+
+    /**
+     * THE BUG (#37): ArchivePack -> ArchiveUnpack must round-trip real
+     * content byte-for-byte. Before the fix, this passes a false green (exit
+     * code 0, no exception) while silently writing a 0-byte file.
+     */
+    public function testPackThenUnpackRoundTripsRealContent() {
+      $sql = $this->realisticSqlDump();
+      file_put_contents(self::BASE . '.sql', $sql);
+
+      $pack = $this->taskArchivePack(self::BASE, self::BASE . '.sql')->rmOrig(true);
+      $packResult = $pack->run();
+      self::assertEquals(0, $packResult->getExitCode(), $packResult->getMessage());
+      self::assertFileExists(self::BASE . '.tar.gz');
+      self::assertFileDoesNotExist(self::BASE . '.sql', 'ArchivePack must remove the original after packing');
+
+      $unpack = $this->taskArchiveUnpack(self::BASE);
+      $unpackResult = $unpack->run();
+      self::assertEquals(0, $unpackResult->getExitCode(), $unpackResult->getMessage());
+
+      self::assertFileExists(self::BASE . '.sql');
+      $roundTripped = file_get_contents(self::BASE . '.sql');
+      self::assertStringContainsString('CREATE TABLE', $roundTripped);
+      self::assertStringContainsString('INSERT INTO', $roundTripped);
+      self::assertStringContainsString('MariaDB dump', $roundTripped);
+      self::assertEquals($sql, $roundTripped, 'Unpacked content must exactly match the original dump, not be truncated');
+    }
+
+  }
+}


### PR DESCRIPTION
Addresses #37

## Root cause

`PharData::compress(Phar::GZ)`, followed by re-opening the resulting `.tar.gz` and calling `extractTo()`, silently writes a **0-byte file** for extracted content:
- `extractTo()` returns `true` — no exception, no error.
- The archive's own entry metadata (`RecursiveIteratorIterator`) correctly reports the original file size.
- The system `tar` binary extracts the exact same `.tar.gz` correctly, with full content.

Confirmed reproducible on **both** macOS PHP 8.3.31 (Homebrew) and Linux PHP 8.3.33 (Debian bookworm, `php:8.3-cli-bookworm` Docker image — matching this repo's CI OS/PHP family, `ubuntu-latest` / PHP 8.3.6 per the `PHP Composer` workflow's own log). This is a genuine PharData defect, not an environment-specific quirk. Plain (uncompressed) `PharData` tar extraction was independently verified unaffected (100/100 bytes correct in the same environments).

## Production impact

`ArchivePack`/`ArchiveUnpack` (used by `SnapshotCreate`'s local-dump producer, `SnapshotRefresh`'s re-export stage, and `SnapshotImport`'s local-dump import path) all depended on this exact round-trip. `snapshot:refresh` against a local/`@self` env, and any `snapshot:get`/`snapshot:restore` import against a locally-produced `.tar.gz`, could silently import/restore **empty SQL** while exiting 0 — the same "passes while proving nothing" failure shape as #33, this time from a PHP extension defect rather than application logic. Existing tests missed this because none asserted content through the real (non-mocked) `ArchiveUnpack` — they either mocked that step, or (in `SnapshotCreateTest::testSnapshotCreateLocally`) independently re-verified via the system `tar` binary rather than trusting `PharData`'s own extraction.

## Fix

`ArchivePack`/`ArchiveUnpack` now use `PharData` for the **tar layer only** (confirmed reliable) and gzip/gunzip via PHP's zlib streams directly, via new `gzipFile()`/`gunzipFile()` helpers added to the shared `TestorTask` base — the same pattern already introduced by `SnapshotViaBackup::gunzipToSql()` for #35 (kept as local, minor duplication there rather than touching that still-open PR's file; noted as a deliberate scope call).

## Tests

- New `ArchivePackUnpackTest::testPackThenUnpackRoundTripsRealContent` — real (non-mocked) `ArchivePack` → `ArchiveUnpack` round-trip, asserts real byte-for-byte SQL content (not exit code, not archive metadata).
  - RED (pre-fix): `Failed asserting that '' contains "CREATE TABLE"` — reproduces the truncation through the actual production code path.
  - GREEN (post-fix): passes, content matches exactly.
  - Re-verified GREEN under Linux PHP 8.3 (Docker) using the repo's own vendored deps, not just locally on macOS.
- Full suite: **57 tests, 330 assertions, all green** (this branch is off `main`, which doesn't yet include #36's tests — no regressions in either).

## Note

This branch is independent of #36 (issue #35) — both are open against `main`. Left a note in the CHANGELOG entry that version numbers will need reconciling whichever merges second.